### PR TITLE
feature/use justify around in card channels

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -87,7 +87,7 @@
 
 .card .channels .channel-inner {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-around;
   padding-bottom: 10px;
   align-items: flex-end;
   border-top: 1px solid #ccc;


### PR DESCRIPTION
I think that e cards look nicer with the contact icons distributed with justify space-around instead of space-between:
previously:
![image](https://user-images.githubusercontent.com/8102016/54703062-6407df00-4b38-11e9-963a-16ffab89f173.png)
with this PR:
![image](https://user-images.githubusercontent.com/8102016/54703103-76821880-4b38-11e9-9573-e44500deea7c.png)

