### PR TITLE
Downcase mentors tags on start to fix search

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -9,10 +9,19 @@ import Logo from "../Logo";
 import SocialLinks from "../SocialLinks/SocialLinks";
 import shuffle from "lodash/shuffle";
 
+
+function downcaseTags(mentors) {
+  return mentors.map(mentor => {
+    mentor.tags = mentor.tags.map(tag => tag.toLowerCase())
+
+    return mentor
+  })
+}
+
 // const serverEndpoint = 'http://localhost:3001';
 class App extends Component {
   state = {
-    mentors: shuffle(mentors)
+    mentors: shuffle(downcaseTags(mentors))
   };
 
   handleTagSelect = async ({ value: tag }) => {


### PR DESCRIPTION
The search for tags compares the tags directly. Since the search always uses downcased tags it fails for tags which have uppercase characters in them.

This PR ensures that the tags are downcased before being loaded into the application.