### PR TITLE
Ensure tags are lowercase with the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Just go to https://mentors.codingcoach.io/ and find her / him / them.
   "title": "NodeJS developer",                  // minLength: 2, maxLength: 30
   "description": "Hi, I'm NodeJs developer",    // minLength: 5, maxLength: 80 optional
   "country": "SE",                              // Country code (link to the list below)
-  "tags": [                                     // minItems: 1, maxItems: 5
+  "tags": [                                     // minItems: 1, maxItems: 5, only lowercase characters
     "nodejs", "webpack", "mongodb"              // please avoid synonyms (see list below)
   ],
   "channels": [                                 // minItems: 1, maxItems: 3

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gh-pages": "^2.0.1",
     "inquirer": "^6.2.2",
     "nodemon": "^1.18.9",
+    "object-path": "^0.11.4",
     "ora": "^3.2.0"
   },
   "homepage": "https://mentors.codingcoach.io",

--- a/scripts/create-user.js
+++ b/scripts/create-user.js
@@ -93,13 +93,28 @@ const questionCountry = {
 };
 
 function validateTags(value) {
-  if (value) {
-    const array = value.split(',');
-    if (array.length > 0 && array.length < 6) {
-      return true;
-    }
+  const hasLessThanOneOrMoreThanFiveTags = (tags) => {
+    const count = tags.split(',').length
+
+    return count < 1 || count > 5
+  };
+  const hasUppercaseCharacters = (tags) => /[A-Z]/.test(tags);
+
+  let errors = [];
+
+  if (hasLessThanOneOrMoreThanFiveTags(value)) {
+    errors.push('between 1 and 5 tags');
   }
-  return 'Please enter valid tags. Between 1 and 5 tags.';
+
+  if (hasUppercaseCharacters(value)) {
+    errors.push('only lowercase characters');
+  }
+
+  if (errors.length > 0) {
+    return `Please enter valid tags: ${errors.join(', ')}.`;
+  }
+
+  return true;
 }
 const questionTags = {
   type: 'input',

--- a/src/__tests__/mentors.json-test.js
+++ b/src/__tests__/mentors.json-test.js
@@ -115,6 +115,7 @@ const mentorSchema = {
           "type": "string",
           "minLength": 1,
           "maxLength": 15,
+          "pattern": "^[^A-Z]*$",
           "synonymsTags": true
         }
       },

--- a/src/__tests__/mentors.json-test.js
+++ b/src/__tests__/mentors.json-test.js
@@ -148,7 +148,11 @@ it('should mentors schema be valid', () => {
       const mentor = mentors[index];
       const fieldValue = getPath(mentor, fieldName.replace("[", ".").replace("]", ""));
 
-      return `error with mentor "${mentor.id}"'s (#${index}) field "${fieldName}"!\n  VALUE: ${fieldValue}\n  ERROR: ${error.message}`;;
+      return [
+        `error with mentor "${mentor.id}"'s (#${index}) field "${fieldName}"!`,
+        `  VALUE: ${fieldValue}`,
+        `  ERROR: ${error.message}`,
+      ].join('\n');
     } catch (error) {
       return error.message;
     }

--- a/src/__tests__/mentors.json-test.js
+++ b/src/__tests__/mentors.json-test.js
@@ -1,5 +1,6 @@
 import mentors from '../mentors.json';
 import Ajv from 'ajv';
+import { get as getPath } from 'object-path';
 import countries from 'svg-country-flags/countries.json';
 
 expect.extend({
@@ -143,8 +144,11 @@ it('should mentors schema be valid', () => {
   const valid = ajv.validate(mentorSchema, mentors);
   const errorMessage = (ajv.errors || []).map(error => {
     try {
-      const [, index, fieldName] = /\[(.*)\].(.*)/.exec(error.dataPath);
-      return `error with item #${index}'s field "${fieldName}". The error is: ${error.message}`;
+      const [, index, fieldName] = /\[(.*)\].(.*)/.exec(error.dataPath)
+      const mentor = mentors[index];
+      const fieldValue = getPath(mentor, fieldName.replace("[", ".").replace("]", ""));
+
+      return `error with mentor "${mentor.id}"'s (#${index}) field "${fieldName}"!\n  VALUE: ${fieldValue}\n  ERROR: ${error.message}`;;
     } catch (error) {
       return error.message;
     }

--- a/src/mentors.json
+++ b/src/mentors.json
@@ -618,7 +618,7 @@
     "country": "IT",
     "tags": [
       "php",
-      "Symfony",
+      "symfony",
       "web",
       "html",
       "git"
@@ -647,7 +647,7 @@
     "country": "CH",
     "tags": [
       "php",
-      "Symfony",
+      "symfony",
       "opensource",
       "databases",
       "speaking"
@@ -942,7 +942,7 @@
       "nodejs",
       "microservices",
       "kubernetes",
-      "C#",
+      "c#",
       "reactjs"
     ],
     "channels": [
@@ -1133,11 +1133,11 @@
     "description": "Hi, My name is Ignacio, if you think I can help you, don't hesitate to tell me.",
     "country": "ES",
     "tags": [
-      "Performance",
-      "Web Typography",
-      "Accessibility",
-      "CSS",
-      "JavaScript"
+      "performance",
+      "web typography",
+      "accessibility",
+      "css",
+      "javascript"
     ],
     "channels": [
       {
@@ -1233,7 +1233,7 @@
     "tags": [
       "javascript",
       "reactjs",
-      "nodeJS",
+      "nodejs",
       "serverless",
       "fullstack"
     ],
@@ -1260,7 +1260,7 @@
     "description": "Hi, I'm a fullstack web developer.",
     "country": "UG",
     "tags": [
-      "JavaScript",
+      "javascript",
       "nodejs",
       "frontend"
     ],
@@ -1544,11 +1544,11 @@
     "description": "Full stack dev with 10+ years of experience in the game, mentor for 4+ years.",
     "country": "RO",
     "tags": [
-      "Javascript",
-      "Angular",
-      "VueJs",
+      "javascript",
+      "angular",
+      "vuejs",
       "dotnet",
-      "MSSQL"
+      "mssql"
     ],
     "channels": [
       {
@@ -1705,9 +1705,9 @@
     "description": "Hey, want to learn some crazy JavaScript stuff? Talk to me",
     "country": "DE",
     "tags": [
-      "Angular",
+      "angular",
       "nodejs",
-      "WebAssembly"
+      "webassembly"
     ],
     "channels": [
       {
@@ -1732,10 +1732,10 @@
     "description": "FOSS enthusiast, Speaker, Mozillian, Python & Rust developer",
     "country": "MX",
     "tags": [
-      "Python",
-      "Rust",
-      "Linux",
-      "OpenSource"
+      "python",
+      "rust",
+      "linux",
+      "opensource"
     ],
     "channels": [
       {
@@ -1756,11 +1756,11 @@
     "description": "JavaScript wrangler and div slinger. Front end, UX and tinkering with stuff.",
     "country": "NL",
     "tags": [
-      "JavaScript",
-      "HTML",
-      "CSS",
-      "ReactJS",
-      "NodeJS"
+      "javascript",
+      "html",
+      "css",
+      "reactjs",
+      "nodejs"
     ],
     "channels": [
       {
@@ -1838,11 +1838,11 @@
     "description": "",
     "country": "US",
     "tags": [
-      "Accessibility",
-      "CSS",
-      "UX",
-      "A11y",
-      "Performance"
+      "accessibility",
+      "css",
+      "ux",
+      "a11y",
+      "performance"
     ],
     "channels": [
       {
@@ -1891,7 +1891,7 @@
       "javascript",
       "nodejs",
       "reactjs",
-      "3D",
+      "3d",
       "gamedev"
     ],
     "channels": [
@@ -1942,9 +1942,9 @@
     "description": "Xamarin Forms mobile application developer, speaker and User group board member",
     "country": "BE",
     "tags": [
-      "C#",
-      "Xamarin Forms",
-      "XAML"
+      "c#",
+      "xamarin forms",
+      "xaml"
     ],
     "channels": [
       {
@@ -1969,11 +1969,11 @@
     "description": "8+ years focused mostly on Javascript/React. Happy to connect and help 😀",
     "country": "US",
     "tags": [
-      "Javascript",
-      "ReactJs",
-      "React Native",
-      "Remote Work",
-      "Frontend"
+      "javascript",
+      "reactjs",
+      "react native",
+      "remote work",
+      "frontend"
     ],
     "channels": [
       {
@@ -2046,11 +2046,11 @@
     "description": "Just converting pizza into code and trying not to overflow! Ready to help! 💖",
     "country": "PL",
     "tags": [
-      "JavaScript",
-      "C#",
-      "Lua",
+      "javascript",
+      "c#",
+      "lua",
       "reactjs",
-      "NodeJS"
+      "nodejs"
     ],
     "channels": [
       {
@@ -2075,11 +2075,11 @@
     "description": "UI guy with 7 years of Experience. Happy to help :)",
     "country": "IN",
     "tags": [
-      "Javascript",
+      "javascript",
       "reactjs",
-      "Html",
-      "Css",
-      "FrontEnd"
+      "html",
+      "css",
+      "frontend"
     ],
     "channels": [
       {
@@ -2104,11 +2104,11 @@
     "description": "All round nice guy :-) 10+ years of experience in building things",
     "country": "NL",
     "tags": [
-      "C#",
-      "Microservices",
-      "Architecture",
-      "Cloud",
-      "Scalability"
+      "c#",
+      "microservices",
+      "architecture",
+      "cloud",
+      "scalability"
     ],
     "channels": [
       {
@@ -2134,8 +2134,8 @@
     "country": "EG",
     "tags": [
       "android",
-      "Kotlin",
-      "Java",
+      "kotlin",
+      "java",
       "nodejs",
       "mobile"
     ],
@@ -2162,11 +2162,11 @@
     "description": "",
     "country": "CA",
     "tags": [
-      "JS",
+      "js",
       "reactjs",
-      "Java",
-      "C++",
-      "Python"
+      "java",
+      "c++",
+      "python"
     ],
     "channels": [
       {
@@ -2239,11 +2239,11 @@
     "description": "I'm specialize in Net Core, MeanJs, Angular, React, Auto Test, Devops, Mobile",
     "country": "VN",
     "tags": [
-      "ASP.Net Core",
-      "Angular",
+      "asp.net core",
+      "angular",
       "reactjs",
-      "Mean Stack, PWA",
-      "DevOps"
+      "mean stack, pwa",
+      "devops"
     ],
     "channels": [
       {
@@ -2328,8 +2328,8 @@
     "tags": [
       "kubernetes",
       "docker",
-      "devOps",
-      "nodeJs",
+      "devops",
+      "nodejs",
       "cloud"
     ],
     "channels": [
@@ -2357,8 +2357,8 @@
     "tags": [
       "reactjs",
       "redux",
-      "C#",
-      "SQL Server"
+      "c#",
+      "sql server"
     ],
     "channels": [
       {
@@ -2466,11 +2466,11 @@
     "description": "Sharing knowledge enriches everyone.",
     "country": "DE",
     "tags": [
-      "JavaScript",
-      "FrontEnd",
-      "NodeJs",
-      "VueJs",
-      "Jest"
+      "javascript",
+      "frontend",
+      "nodejs",
+      "vuejs",
+      "jest"
     ],
     "channels": [
       {
@@ -2495,11 +2495,11 @@
     "description": "As much in love with UX/UI as programming.",
     "country": "FR",
     "tags": [
-      "Javascript",
-      "ReactJS",
-      "NodeJs",
-      "UX",
-      "UI"
+      "javascript",
+      "reactjs",
+      "nodejs",
+      "ux",
+      "ui"
     ],
     "channels": [
       {
@@ -2526,7 +2526,7 @@
     "tags": [
       "php",
       "css",
-      "C#",
+      "c#",
       "fullstack",
       "javascript"
     ],
@@ -2829,11 +2829,11 @@
     "description": "I can help you with Software Design, Elixir, Ruby, and Rails.",
     "country": "MX",
     "tags": [
-      "Elixir",
-      "Ruby",
-      "Rails",
-      "Backend",
-      "PostgreSQL"
+      "elixir",
+      "ruby",
+      "rails",
+      "backend",
+      "postgresql"
     ],
     "channels": [
       {
@@ -3026,11 +3026,11 @@
     "description": "Eloquent JS is my jam!",
     "country": "IN",
     "tags": [
-      "JavaScript",
-      "ReactJS",
-      "NodeJS",
-      "Linux",
-      "FP"
+      "javascript",
+      "reactjs",
+      "nodejs",
+      "linux",
+      "fp"
     ],
     "channels": [
       {
@@ -3055,10 +3055,10 @@
     "description": "It's a fact that you have to start to be great, so why not start together.",
     "country": "DZ",
     "tags": [
-      "Android",
-      "Java",
-      "Kotlin",
-      "Reactjs"
+      "android",
+      "java",
+      "kotlin",
+      "reactjs"
     ],
     "channels": [
       {
@@ -3083,11 +3083,11 @@
     "description": "Full-stack developer. I love React and Nodejs. Feel free to reach me!",
     "country": "PK",
     "tags": [
-      "Nodejs",
-      "Reactjs",
-      "MongoDB",
-      "GraphQL",
-      "Socket.io"
+      "nodejs",
+      "reactjs",
+      "mongodb",
+      "graphql",
+      "socket.io"
     ],
     "channels": [
       {
@@ -3112,9 +3112,9 @@
     "description": "I work in CSS and React and really love all the quirks of JavaScript!",
     "country": "US",
     "tags": [
-      "JavaScript",
-      "ReactJS",
-      "CSS",
+      "javascript",
+      "reactjs",
+      "css",
       "frontend"
     ],
     "channels": [
@@ -3140,11 +3140,11 @@
     "description": "Eloquent JS is my jam!",
     "country": "IN",
     "tags": [
-      "JavaScript",
-      "ReactJS",
-      "NodeJS",
-      "Linux",
-      "FP"
+      "javascript",
+      "reactjs",
+      "nodejs",
+      "linux",
+      "fp"
     ],
     "channels": [
       {
@@ -3169,11 +3169,11 @@
     "description": "Mobile App Developer (React Native)",
     "country": "IN",
     "tags": [
-      "JavaScript",
-      "Reactjs",
-      "React Native",
-      "HTML",
-      "CSS"
+      "javascript",
+      "reactjs",
+      "react native",
+      "html",
+      "css"
     ],
     "channels": [
       {
@@ -3228,8 +3228,8 @@
     "tags": [
       "elixir",
       "backend",
-      "FP",
-      "DDD",
+      "fp",
+      "ddd",
       "compassion"
     ],
     "channels": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6821,6 +6821,11 @@ object-keys@^1.0.11, object-keys@^1.0.12:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
   integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
 
+object-path@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
+  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"


### PR DESCRIPTION
The search for tags compares the tags directly. Since the search always uses downcased tags it fails for tags which have uppercase characters in them.

This PR adds a restriction to the tests to ensure that the tags are all lowercase. It does this by adding a `pattern` criteria to the tags JSON schema. It also improves the output for the schema test to actually display the violating value and the mentor which makes finding offending values a lot more easy.

