### PR TITLE
Add meta description to improve seo audit to 100%

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
+    <meta name="Description" content="You want to learn a new skill? Steer away from doubts? Looking for someone to discuss? Coding Coach is here to connect you with mentors worldwide!">
+    
     <!-- Open Graph data -->
     <meta property="og:title" content="Coding Coach">
     <meta property="og:type" content="article">

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
-    <meta name="Description" content="You want to learn a new skill? Steer away from doubts? Looking for someone to discuss? Coding Coach is here to connect you with mentors worldwide!">
+    <meta name="Description" content="Coding Coach is here to connect mentors and mentees around the world, for free. We believe mentorship should be accessible to all, regardless of circumstance.">
     
     <!-- Open Graph data -->
     <meta property="og:title" content="Coding Coach">


### PR DESCRIPTION
Added a meta description so that we pass the seo audit to 100, the current one online:
<img width="383" alt="seo-audit" src="https://user-images.githubusercontent.com/39331790/55465246-9f081900-55f4-11e9-8137-3593fafdad54.PNG">

Normally this should be a call to action, just need to decide on the text we use 😃 
I made a quick one, but needs improvements, this should be between 130-160 letters

Some examples at the end of this article:
https://www.2dogsdesign.com/what-is-meta-description/