### PR TITLE
Fix tag count validation in add-user script

### DIFF
--- a/scripts/create-user.js
+++ b/scripts/create-user.js
@@ -118,7 +118,7 @@ function validateTags(value) {
   const hasLessThanOneOrMoreThanFiveTags = tags => {
     const count = tags.split(',').length;
 
-    return count < 1 || count > 5;
+    return !tags || count > 5;
   };
   const hasUppercaseCharacters = tags => /[A-Z]/.test(tags);
 


### PR DESCRIPTION
Fixing method _hasLessThanOneOrMoreThanFiveTags_

If you just press Enter without typing a tag the value will be ' ' and when you split it will produce [' '] therefore if no tag is sent count will be 1 passing this validation with no tags

if we change to this it solves the empty problem 😄 