### PR TITLE
Fixing emoji flag for "Northern Ireland"

### DIFF
--- a/src/mentors.json
+++ b/src/mentors.json
@@ -4144,7 +4144,7 @@
     "avatar": "https://secure.gravatar.com/avatar/b5e2b9ab04e9fa5710c3fd325c554ba7?size=800",
     "title": "Full stack web developer",
     "description": "JS and web enthusiast",
-    "country": "GB-NIR",
+    "country": "IE",
     "tags": [
       "js",
       "reactjs",


### PR DESCRIPTION
<img width="227" alt="image" src="https://user-images.githubusercontent.com/7671983/55576244-1df27400-5711-11e9-9681-b2888798a335.png">


The Northern Ireland flag isn't appearing so I changed it to render the flag for "Ireland."

<img width="311" alt="image" src="https://user-images.githubusercontent.com/7671983/55576261-2ba7f980-5711-11e9-96f2-e484d211acc4.png">
