### PR TITLE
Centralize Synonyms Check for Tags

### DIFF
--- a/scripts/create-user.js
+++ b/scripts/create-user.js
@@ -1,6 +1,7 @@
 'use strict';
 const inquirer = require('inquirer');
 const countries = require('svg-country-flags/countries.json');
+const checkSynonyms = require('../src/checkSynonymsTags');
 
 function validateEmail(value) {
   const pass = value.match(
@@ -87,30 +88,14 @@ const questionCountry = {
 };
 
 function validateTags(value) {
-  const synonymsTags = {
-    '(node|node.js)': 'nodejs',
-    '(react|React.js)': 'reactjs',
-    vue: 'vuejs',
-    'react-native': 'react native',
-    csharp: 'c#',
-    'front end': 'frontend',
-    expressjs: 'express',
-    'full stack': 'fullstack',
-  };
-
   const hasSynonymsErrors = tags => {
     const tagsArray = tags.split(',');
     let errors = [];
     tagsArray.forEach(tag => {
-      Object.keys(synonymsTags).forEach(synonym => {
-        if (new RegExp(`^${synonym}$`, 'i').exec(tag)) {
-          errors.push(
-            `should NOT use "${tag}", should use the conventional name: "${
-              synonymsTags[synonym]
-            }"`
-          );
-        }
-      });
+      const synonymError = checkSynonyms(tag);
+      if (synonymError) {
+        errors.push(synonymError);
+      }
     });
     return errors;
   };

--- a/src/__tests__/mentors.json-test.js
+++ b/src/__tests__/mentors.json-test.js
@@ -3,6 +3,7 @@ import Ajv from 'ajv';
 import { get as getPath } from 'object-path';
 import countries from 'svg-country-flags/countries.json';
 import _ from 'lodash';
+import checkSynonyms from '../checkSynonymsTags';
 
 expect.extend({
   toBeValid(isValid, errorMessage) {
@@ -26,28 +27,15 @@ const validateSecuredUrl = function(schema, uri) {
   return uri.indexOf('https://') === 0;
 };
 
-const synonymsTags = {
-  '(node|node.js)': 'nodejs',
-  '(react|React.js)': 'reactjs',
-  vue: 'vuejs',
-  'react-native': 'react native',
-  csharp: 'c#',
-  'front end': 'frontend',
-  expressjs: 'express',
-  'full stack': 'fullstack',
-};
-
 const validateSynonymsTags = function(schema, tag) {
   let isValid = true;
   let message = '';
-  Object.keys(synonymsTags).forEach(synonym => {
-    if (new RegExp(`^${synonym}$`, 'i').exec(tag)) {
-      message = `should NOT use "${tag}", should use the conventional name: "${
-        synonymsTags[synonym]
-      }"`;
-      isValid = false;
-    }
-  });
+  const synonymError = checkSynonyms(tag);
+
+  if (synonymError) {
+    message = synonymError;
+    isValid = false;
+  }
 
   validateSynonymsTags.errors = [
     { keyword: 'synonymsTags', message, params: { keyword: 'synonymsTags' } },

--- a/src/checkSynonymsTags.js
+++ b/src/checkSynonymsTags.js
@@ -1,0 +1,22 @@
+const synonymsTags = {
+  '(node|node.js)': 'nodejs',
+  '(react|React.js)': 'reactjs',
+  vue: 'vuejs',
+  'react-native': 'react native',
+  csharp: 'c#',
+  'front end': 'frontend',
+  expressjs: 'express',
+  'full stack': 'fullstack',
+};
+
+module.exports = function(tag) {
+  let message = null;
+  Object.keys(synonymsTags).forEach(synonym => {
+    if (new RegExp(`^${synonym}$`, 'i').exec(tag)) {
+      message = `should NOT use "${tag}", should use the conventional name: "${
+        synonymsTags[synonym]
+      }"`;
+    }
+  });
+  return message;
+};


### PR DESCRIPTION
Put the synonyms check for tags in one place only, as request by @moshfeu 

Can it be improved?