### PR TITLE
Add key to Obfuscate to remove warning when you run tests

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -40,6 +40,7 @@ const channelsList = channels => {
     if (channel.type === 'email') {
       return (
         <Obfuscate
+          key={channel.type}
           email={url.substring('mailto:'.length)}
           linkText=""
           onClick={() => handleAnalytic(`${channel.type}`)}


### PR DESCRIPTION
Fixes this:
<img width="616" alt="keyError" src="https://user-images.githubusercontent.com/39331790/55618797-4751e500-578f-11e9-9c35-1c54876496d6.PNG">
