### PR TITLE
Added italic version of Lato.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
         integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,400i" rel="stylesheet">
     <title>Coding Coach</title>
     <!-- Google Analytics -->
     <script>

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
         integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/css?family=Lato:400,400i" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css?family=Lato:400,400i" as="font" type="font/woff2" crossOrigin="true">
     <title>Coding Coach</title>
     <!-- Google Analytics -->
     <script>


### PR DESCRIPTION
This is missing as it looks very bad.

@emmawedekind and @moshfeu see how it looks ("Full Stack Developer, LAMP / MERN Stack specialising in UX & Front End Tech." part):

![without italic](https://user-images.githubusercontent.com/1830380/55640657-fe685380-57c3-11e9-9ea0-fab4c296b2b9.png)

If we have added the right fonts by including Lato Italic and then using it, it looks like this:

![with italic](https://user-images.githubusercontent.com/1830380/55640734-235cc680-57c4-11e9-9d5a-e42b194e9574.png)

Hence the PR. 😅