### PR TITLE
Task/i 294/update card styles

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -12,6 +12,7 @@
   margin-top: calc(var(--avatar-offset) + 20px);
   margin-right: 5px;
   margin-left: 5px;
+  box-shadow: -1px 2px 5px 0 rgba(95, 95, 95, 0.2);
 }
 
 .card .country {

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   width: 280px;
-  padding: 0 32px;
+  padding: 0 20px;
   border-radius: 5px;
   text-align: center;
   position: relative;
@@ -15,9 +15,11 @@
 }
 
 .card .country {
-  position: absolute;
-  top: 10px;
-  left: 10px;
+  padding-top: 10px;
+  color: #4a4a4a;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .card .avatar {
@@ -137,9 +139,6 @@
 }
 
 .card .like-button {
-  position: absolute;
-  top: 10px;
-  right: 10px;
   background: none;
   border: none;
   cursor: pointer;

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -15,7 +15,6 @@
 }
 
 .card .country {
-  padding-top: 10px;
   color: #4a4a4a;
   display: flex;
   flex-direction: row;
@@ -59,11 +58,14 @@
 .card .title {
   color: #999;
   margin: 0 0 5px;
+  font-weight: 400;
 }
 
 .card .description {
   font-style: italic;
-  background: rgba(21, 21, 21, 0.01);
+
+  color: #16385c;
+  font-weight: 600;
   margin-bottom: 5px;
   padding: 5px 2.5px;
   border-radius: 10px;
@@ -76,7 +78,7 @@
 
 .card .tag {
   color: #fff;
-  background: var(--tag-color);
+  background: #16385c;
   border: 0;
   border-radius: 20px;
   display: inline-block;
@@ -101,13 +103,14 @@
 .card .channels .channel-inner {
   display: flex;
   justify-content: space-between;
-  border-top: 1px solid #ccc;
+
+  background-color: #d0f8ef;
   align-items: center;
   padding: 10px;
 }
 
 .card .channels a {
-  color: #9b9b9b;
+  color: #16385c;
   text-decoration: none;
 }
 

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -12,6 +12,8 @@
   margin-right: 5px;
   margin-left: 5px;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+  display: grid;
+  grid-auto-rows: 80px minmax(140px, auto) minmax(80px, auto) 80px;
 }
 .card .header {
   display: flex;
@@ -82,7 +84,6 @@
   color: #16385c;
   font-weight: 600;
   margin-top: 0;
-  margin-bottom: 30px;
   padding: 5px 2.5px;
   border-radius: 10px;
 }

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -13,7 +13,7 @@
   margin-left: 5px;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
   display: grid;
-  grid-auto-rows: 80px minmax(140px, auto) minmax(80px, auto) 80px;
+  grid-auto-rows: 80px minmax(140px, auto) minmax(60px, auto) 80px;
 }
 .card .header {
   display: flex;
@@ -90,7 +90,6 @@
 
 .card .tags {
   z-index: 2;
-  margin-bottom: 10px;
 }
 
 .card .tag {

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -72,6 +72,7 @@
 }
 
 .card .tags {
+  z-index: 2;
   margin-bottom: 10px;
   margin: 10px -10px;
 }
@@ -107,6 +108,18 @@
   background-color: #d0f8ef;
   align-items: center;
   padding: 10px;
+  margin-right: -20px;
+  margin-left: -20px;
+}
+.card .wave {
+  position: absolute;
+  bottom: 60px;
+  left: 0;
+  background-color: white;
+  height: 30px;
+  width: 100%;
+  border-bottom-left-radius: 100%;
+  border-bottom-right-radius: 100%;
 }
 
 .card .channels a {

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -119,11 +119,11 @@
 
 .card .channels .channel-inner {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-around;
 
   background-color: #d0f8ef;
   align-items: center;
-  padding: 10px;
+  padding: 20px 10px 5px 10px;
   margin-right: -20px;
   margin-left: -20px;
 }
@@ -134,8 +134,7 @@
   background-color: hsl(0, 0%, 100%);
   height: 30px;
   width: 100%;
-  border-bottom-left-radius: 100%;
-  border-bottom-right-radius: 100%;
+  border-radius: 0% 0% 50% 50%;
 }
 
 .card .channels a {

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -8,11 +8,10 @@
   border-radius: 5px;
   text-align: center;
   position: relative;
-  border: 1px solid #ccc;
   margin-top: calc(var(--avatar-offset) + 20px);
   margin-right: 5px;
   margin-left: 5px;
-  box-shadow: -1px 2px 5px 0 rgba(95, 95, 95, 0.2);
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
 }
 
 .card .country {
@@ -67,7 +66,8 @@
 
   color: #16385c;
   font-weight: 600;
-  margin-bottom: 5px;
+  margin-top: 0;
+  margin-bottom: 30px;
   padding: 5px 2.5px;
   border-radius: 10px;
 }
@@ -75,7 +75,6 @@
 .card .tags {
   z-index: 2;
   margin-bottom: 10px;
-  margin: 10px -10px;
 }
 
 .card .tag {

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -13,9 +13,24 @@
   margin-left: 5px;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
 }
+.card .header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 17px;
+}
+
+.card .location i {
+  margin-right: 5px;
+}
+
+.card .location p {
+  margin: 0;
+  margin-top: 2px;
+}
 
 .card .country {
-  color: #4a4a4a;
+  color: hsl(0, 0%, 29%);
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -32,7 +47,7 @@
   font-size: var(--avatar-dim);
   width: var(--avatar-dim);
   height: var(--avatar-dim);
-  background: #fff;
+  background: hsl(0, 0%, 100%);
   color: rgb(155, 155, 155);
   border-radius: 50%;
   box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14),
@@ -50,13 +65,13 @@
 }
 
 .card .name {
-  color: #4a4a4a;
+  color: hsl(0, 0%, 29%);
   font-size: 20px;
   margin: 0 0 5px;
 }
 
 .card .title {
-  color: #999;
+  color: hsl(0, 0%, 29%);
   margin: 0 0 5px;
   font-weight: 400;
 }
@@ -78,7 +93,7 @@
 }
 
 .card .tag {
-  color: #fff;
+  color: hsl(0, 0%, 100%);
   background: #16385c;
   border: 0;
   border-radius: 20px;
@@ -115,7 +130,7 @@
   position: absolute;
   bottom: 60px;
   left: 0;
-  background-color: white;
+  background-color: hsl(0, 0%, 100%);
   height: 30px;
   width: 100%;
   border-bottom-left-radius: 100%;
@@ -162,7 +177,7 @@
 
 .card .liked,
 .card .like-button:hover i {
-  color: #db2828;
+  color: hsl(0, 71%, 51%);
 }
 
 @media all and (max-width: 575.98px) {

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -103,6 +103,7 @@
   line-height: 1;
   user-select: none;
   text-transform: lowercase;
+  font-family: monospace;
 }
 
 .card .tag:hover {

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -99,7 +99,7 @@ const LikeButton = ({ onClick, liked }) => (
   </button>
 );
 
-const Info = ({ mentor, handleTagClick }) => {
+const CardBody = ({ mentor, handleTagClick }) => {
   // Don't show the description if it's not provided.
   const description = mentor.description ? (
     <p className="description">"{mentor.description}"</p>
@@ -107,19 +107,41 @@ const Info = ({ mentor, handleTagClick }) => {
     <React.Fragment />
   );
 
+  const MentorInfo = () => {
+    return (
+      <>
+        <div>
+          <h1 className="name" id={`${generateMentorId(mentor.name)}-name`}>
+            {mentor.name}
+          </h1>
+          <h4 className="title">{mentor.title}</h4>
+          {description}
+        </div>
+      </>
+    );
+  };
+
+  const SkillsTags = () => {
+    return <div className="tags">{tagsList(mentor.tags, handleTagClick)}</div>;
+  };
+
+  const CardFooter = () => {
+    return (
+      <>
+        <div className="wave" />
+        <div className="channels">
+          <div className="channel-inner">{channelsList(mentor.channels)}</div>
+        </div>
+      </>
+    );
+  };
+
   return (
-    <React.Fragment>
-      <h1 className="name" id={`${generateMentorId(mentor.name)}-name`}>
-        {mentor.name}
-      </h1>
-      <h4 className="title">{mentor.title}</h4>
-      {description}
-      <div className="tags">{tagsList(mentor.tags, handleTagClick)}</div>
-      <div className="wave" />
-      <div className="channels">
-        <div className="channel-inner">{channelsList(mentor.channels)}</div>
-      </div>
-    </React.Fragment>
+    <>
+      <MentorInfo />
+      <SkillsTags />
+      <CardFooter />
+    </>
   );
 };
 
@@ -129,8 +151,8 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
     onFavMentor(mentor);
   };
 
-  return (
-    <div className="card" aria-label="Mentor card">
+  const Header = () => {
+    return (
       <div className="header">
         <div className="country location">
           <i className={'fa fa-map-marker'} />
@@ -140,7 +162,12 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
         <Avatar mentor={mentor} />
         <LikeButton onClick={toggleFav} liked={isFav} />
       </div>
-      <Info mentor={mentor} handleTagClick={handleTagClick} />
+    );
+  };
+  return (
+    <div className="card" aria-label="Mentor card">
+      <Header />
+      <CardBody mentor={mentor} handleTagClick={handleTagClick} />
     </div>
   );
 };

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -99,8 +99,13 @@ const LikeButton = ({ onClick, liked }) => (
   </button>
 );
 
-const CardBody = ({ mentor, handleTagClick }) => {
-  // Don't show the description if it's not provided.
+const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
+  const toggleFav = () => {
+    isFav = !isFav;
+    onFavMentor(mentor);
+  };
+
+  // don't show the description if it's not provided
   const description = mentor.description ? (
     <p className="description">"{mentor.description}"</p>
   ) : (
@@ -136,21 +141,6 @@ const CardBody = ({ mentor, handleTagClick }) => {
     );
   };
 
-  return (
-    <>
-      <MentorInfo />
-      <SkillsTags />
-      <CardFooter />
-    </>
-  );
-};
-
-const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
-  const toggleFav = () => {
-    isFav = !isFav;
-    onFavMentor(mentor);
-  };
-
   const Header = () => {
     return (
       <div className="header">
@@ -167,7 +157,9 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
   return (
     <div className="card" aria-label="Mentor card">
       <Header />
-      <CardBody mentor={mentor} handleTagClick={handleTagClick} />
+      <MentorInfo />
+      <SkillsTags />
+      <CardFooter />
     </div>
   );
 };

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -131,17 +131,10 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
 
   return (
     <div className="card" aria-label="Mentor card">
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          fontSize: '17px',
-        }}
-      >
-        <div className="country">
-          <i style={{ marginRight: '5px' }} className={'fa fa-map-marker'} />
-          <p style={{ margin: '0', marginTop: '2px' }}>{mentor.country}</p>
+      <div className="header">
+        <div className="country location">
+          <i className={'fa fa-map-marker'} />
+          <p>{mentor.country}</p>
         </div>
 
         <Avatar mentor={mentor} />

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -131,13 +131,21 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
 
   return (
     <div className="card" aria-label="Mentor card">
-      <LikeButton onClick={toggleFav} liked={isFav} />
-      <img
-        className="country"
-        src={`https://www.countryflags.io/${mentor.country}/flat/32.png`}
-        alt={countries[mentor.country]}
-      />
-      <Avatar mentor={mentor} />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div className="country">
+          <i style={{ marginRight: '5px' }} className={'fa fa-map-marker'} />
+          <p style={{ margin: '0' }}>{mentor.country}</p>
+        </div>
+
+        <Avatar mentor={mentor} />
+        <LikeButton onClick={toggleFav} liked={isFav} />
+      </div>
       <Info mentor={mentor} handleTagClick={handleTagClick} />
     </div>
   );

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -4,7 +4,6 @@ import { orderBy } from 'lodash';
 import './Card.css';
 import { getChannelInfo } from '../../channelProvider';
 import classNames from 'classnames';
-import countries from 'svg-country-flags/countries.json';
 
 const generateMentorId = name => {
   return name.replace(/\s/g, '-');
@@ -136,11 +135,12 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
+          fontSize: '17px',
         }}
       >
         <div className="country">
           <i style={{ marginRight: '5px' }} className={'fa fa-map-marker'} />
-          <p style={{ margin: '0' }}>{mentor.country}</p>
+          <p style={{ margin: '0', marginTop: '2px' }}>{mentor.country}</p>
         </div>
 
         <Avatar mentor={mentor} />

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -115,6 +115,7 @@ const Info = ({ mentor, handleTagClick }) => {
       <h4 className="title">{mentor.title}</h4>
       {description}
       <div className="tags">{tagsList(mentor.tags, handleTagClick)}</div>
+      <div className="wave" />
       <div className="channels">
         <div className="channel-inner">{channelsList(mentor.channels)}</div>
       </div>

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -141,7 +141,7 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
     );
   };
 
-  const Header = () => {
+  const CardHeader = () => {
     return (
       <div className="header">
         <div className="country location">
@@ -156,7 +156,7 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
   };
   return (
     <div className="card" aria-label="Mentor card">
-      <Header />
+      <CardHeader />
       <MentorInfo />
       <SkillsTags />
       <CardFooter />


### PR DESCRIPTION
👋 This PR aims to solve issue #294. You can see the updated styling of the cards here: 

<img width="952" alt="Screenshot 2019-04-14 21 57 53" src="https://user-images.githubusercontent.com/26777813/56099083-645d8500-5f00-11e9-8e30-99d08af17737.png">

There were a couple of issues that need addressed:
1. there doesn't seem to be enough space for the full country name. It results in weird formatting of countries with a name longer than one word and there was an issue with the avatar being pushed over by the text, but that's easily resolved: 
<img width="581" alt="Screenshot 2019-04-14 21 56 15" src="https://user-images.githubusercontent.com/26777813/56099104-ab4b7a80-5f00-11e9-9f21-8ec5de1e47f0.png">
2. If a mentor has plenty of information, the elements move downwards, meaning that the card next to it has a different "layout" of elements: 
<img width="584" alt="Screenshot 2019-04-14 22 01 28" src="https://user-images.githubusercontent.com/26777813/56099146-1bf29700-5f01-11e9-8294-b4a65192552c.png">


I'd like to resolve this ☝🏻using CSS grid to keep the elements in a set space. But would like to do this in a separate PR. 