### PR TITLE
increase items per page for infinite scroll list

### DIFF
--- a/src/components/MentorsList/MentorsList.js
+++ b/src/components/MentorsList/MentorsList.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import InfiniteScroll from 'react-infinite-scroller';
 import Card from '../Card/Card';
 
-const itemsInPage = 10;
+const itemsInPage = 20;
 
 export default class MentorsLists extends Component {
   state = {


### PR DESCRIPTION
resolves #329 

The bug of the window jumping back to the top was only occurring when on a larger screen width with 5 or more mentor card items per row. So i think it has something to do with how the mentors list is being rendered/re-rendered in the infinite scroll component based on pages. When the `itemsInPage` value is greater than the total of items in 2 rows, it seems to solve the bug. I've tried stepping through code with a debugger to figure out why this fixes it, but still not sure. 

If anyone else wants to look into it and understands why, and/or propose an alternate solution, let me know! 