### PR TITLE
[issues/307] Website format validation as part of ajv schema check

### DIFF
--- a/src/__tests__/mentors.json-test.js
+++ b/src/__tests__/mentors.json-test.js
@@ -64,6 +64,16 @@ const validateDescription = function(schema, description) {
   return isValid;
 };
 
+const validateWebsite = function(schema, website) {
+  const pattern = /^((http|https):\/\/)/;
+  const message = 'should not contain http/s';
+
+  validateWebsite.errors = [
+    { keyword: 'website', message, params: { keyword: 'website' } },
+  ];
+  return !pattern.test(website);
+};
+
 ajv.addKeyword('securedUrl', {
   validate: validateSecuredUrl,
   errors: true,
@@ -76,6 +86,11 @@ ajv.addKeyword('suitableDescription', {
 
 ajv.addKeyword('synonymsTags', {
   validate: validateSynonymsTags,
+  errors: true,
+});
+
+ajv.addKeyword('validWebsite', {
+  validate: validateWebsite,
   errors: true,
 });
 
@@ -140,6 +155,16 @@ const mentorSchema = {
                 'github',
                 'website',
               ],
+            },
+          },
+          if: {
+            properties: {
+              type: { enum: ['website'] },
+            },
+          },
+          then: {
+            properties: {
+              id: { validWebsite: true },
             },
           },
           required: ['type', 'id'],


### PR DESCRIPTION
As suggested in https://github.com/Coding-Coach/find-a-mentor/issues/307#issuecomment-483548210 website format validation can be moved to global schema check--

To-do:
- [ ] Fix error message displayed when incorrect url format is encountered, currently it appears as 
<img width="472" alt="Screen Shot 2019-04-25 at 12 07 25 AM" src="https://user-images.githubusercontent.com/20274885/56675217-275a7500-66ee-11e9-9347-5749a72727b1.png">
instead of: 
<img width="460" alt="Screen Shot 2019-04-25 at 12 09 31 AM" src="https://user-images.githubusercontent.com/20274885/56675341-70aac480-66ee-11e9-83e3-080b4bcd9f83.png">

because
https://github.com/Coding-Coach/find-a-mentor/blob/e30f89c08dbd8a0a9076330438601af1ae785cb3/src/__tests__/mentors.json-test.js#L176 replaces `channels[0]` with `channels.0`.

Will fix shortly c: