### PR TITLE
issue/338-modals-extend-past-fold

### DIFF
--- a/src/components/Content/Content.css
+++ b/src/components/Content/Content.css
@@ -1,9 +1,3 @@
-
-.is-modal {
-  overflow-y: scroll;
-  position: fixed;
-}
-
 .modal-container {
   background: rgba(100,100,100,0.8);
   width: 100%;

--- a/src/components/Content/Content.css
+++ b/src/components/Content/Content.css
@@ -1,6 +1,7 @@
 
 .is-modal {
-  overflow: hidden;
+  overflow-y: scroll;
+  position: fixed;
 }
 
 .modal-container {

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -1,8 +1,3 @@
-.is-modal {
-  overflow-y: scroll;
-  position: fixed;
-}
-
 .modal-container {
   display: flex;
   flex-direction: column;

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -13,7 +13,6 @@
   top: 0px;
   left: 0px;
   pointer-events: none;
-  overflow: none;
   z-index: -1;
   opacity: 0;
   transition: all 0.2s ease-in-out;
@@ -29,8 +28,7 @@
   background: #fff;
   max-width: 780px;
   width: 95%;
-  /* height: 80vh; */
-  /* max-height: 80vh; */
+  max-height: 80vh;
   min-height: 100px;
   border-radius: 5px;
   margin: 300px auto;

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -89,7 +89,7 @@
 .scroll-helper {
   height: calc(80vh - 200px);
   overflow-y: scroll;
-  margin-bottom: 25px;
+  margin: 0 auto 10px auto;
 }
 
 @media all and (max-width: 800px) {

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -3,6 +3,9 @@
 }
 
 .modal-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   background: rgba(100,100,100,0.8);
   width: 100%;
   height: 100%;
@@ -10,7 +13,7 @@
   top: 0px;
   left: 0px;
   pointer-events: none;
-  overflow: scroll;
+  overflow: none;
   z-index: -1;
   opacity: 0;
   transition: all 0.2s ease-in-out;
@@ -26,12 +29,15 @@
   background: #fff;
   max-width: 780px;
   width: 95%;
+  /* height: 80vh; */
+  /* max-height: 80vh; */
   min-height: 100px;
   border-radius: 5px;
   margin: 300px auto;
   opacity: 0;
   position: relative;
   transition: all 0.4s ease-in-out;
+  overflow: hidden;
 }
 
 @media all and (max-width: 576px) {
@@ -76,10 +82,15 @@
   margin: 0px;
 }
 .modal-container .modal-box .modal-content {
-  padding: 15px 25px;
+  padding: 15px 25px 25px 25px;
   color: #000022;
+  overflow: hidden;
 }
-
+.scroll-helper {
+  height: calc(80vh - 200px);
+  overflow-y: scroll;
+  margin-bottom: 25px;
+}
 
 @media all and (max-width: 800px) {
   .modal-container .modal-box {

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -1,5 +1,6 @@
 .is-modal {
-  overflow: hidden;
+  overflow-y: scroll;
+  position: fixed;
 }
 
 .modal-container {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -10,7 +10,6 @@ export default class Modal extends Component {
     this.setState({
       isActive: true,
     });
-    document.body.classList.add('is-modal');
   };
 
   handleClose = () => {
@@ -23,7 +22,6 @@ export default class Modal extends Component {
     if (typeof onClose === 'function') {
       onClose();
     }
-    document.body.classList.remove('is-modal');
   };
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -45,7 +45,9 @@ export default class Modal extends Component {
           <div className="modal-head">
             <h2>{title || ''}</h2>
           </div>
-          <div className="modal-content">{children || ''}</div>
+          <div className="scroll-helper">
+            <div className="modal-content">{children || ''}</div>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
Minor CSS tweaks to ensure content scrolls within modal and modal doesn't extend beyond the fold. Also disable main site scroll when modal is open.

Modal header not included in scroll to ensure close button remains in place.

Will resolve #338 