### PR TITLE
feat: clickable location tags to filter mentor list

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -90,6 +90,14 @@ class App extends Component {
     window.ga('send', 'event', 'Filter', 'click', 'tag', clickedTag);
   };
 
+  handleCountryClick = async clickedCountry => {
+    await scrollToTop();
+    this.setState({
+      clickedCountry,
+    });
+    window.ga('send', 'event', 'Filter', 'click', 'country', clickedCountry);
+  };
+
   getPermalinkParams() {
     const permalink = new URLSearchParams(window.location.search);
 
@@ -125,7 +133,13 @@ class App extends Component {
   };
 
   render() {
-    const { mentors, fieldsIsActive, modal, clickedTag } = this.state;
+    const {
+      mentors,
+      fieldsIsActive,
+      modal,
+      clickedTag,
+      clickedCountry,
+    } = this.state;
     const mentorsInList = mentors.filter(this.filterMentors);
 
     return (
@@ -146,6 +160,7 @@ class App extends Component {
               onToggleSwitch={this.toggleSwitch}
               mentorCount={mentorsInList.length}
               clickedTag={clickedTag}
+              clickedCountry={clickedCountry}
             />
             <SocialLinks />
 
@@ -203,6 +218,7 @@ class App extends Component {
             favorites={this.state.favorites}
             onFavMentor={this.onFavMentor}
             handleTagClick={this.handleTagClick}
+            handleCountryClick={this.handleCountryClick}
           />
         </main>
       </div>

--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -60,12 +60,21 @@ export default class AutoComplete extends Component {
 
   setPermalinkParams = (param, value) => {
     const permalink = new URLSearchParams(window.location.search);
-    const paramItem = this.props.source.filter(item => item.label === value);
-    if (paramItem.length && value.length) {
-      permalink.set(param, paramItem[0].value);
-    } else if (!value.length) {
-      permalink.delete(param);
+
+    switch (param) {
+      case 'language':
+        const paramItem = this.props.source.find(item => item.label === value);
+        if (paramItem && value.length) {
+          permalink.set(param, paramItem.value);
+        } else if (!value.length) {
+          permalink.delete(param);
+        }
+        break;
+      default:
+        permalink.set(param, value);
+        break;
     }
+
     window.history.pushState({}, null, '?' + permalink.toString());
   };
 

--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -60,21 +60,12 @@ export default class AutoComplete extends Component {
 
   setPermalinkParams = (param, value) => {
     const permalink = new URLSearchParams(window.location.search);
-
-    switch (param) {
-      case 'language':
-        const paramItem = this.props.source.find(item => item.label === value);
-        if (paramItem && value.length) {
-          permalink.set(param, paramItem.value);
-        } else if (!value.length) {
-          permalink.delete(param);
-        }
-        break;
-      default:
-        permalink.set(param, value);
-        break;
+    const paramItem = this.props.source.filter(item => item.label === value);
+    if (paramItem.length && value.length) {
+      permalink.set(param, paramItem[0].value);
+    } else if (!value.length) {
+      permalink.delete(param);
     }
-
     window.history.pushState({}, null, '?' + permalink.toString());
   };
 
@@ -83,12 +74,22 @@ export default class AutoComplete extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { clickedTag: value } = this.props;
+    const { clickedTag: value, clickedCountry } = this.props;
 
     if (prevProps.clickedTag !== this.props.clickedTag) {
       this.setState({ value });
       this.props.onSelect({ value });
       this.setPermalinkParams(this.props.id, value);
+    }
+
+    if (prevProps.clickedCountry !== clickedCountry) {
+      const code = this.props.source.find(
+        item => item.value === clickedCountry
+      );
+
+      this.setState({ value: code.label });
+      this.props.onSelect({ value: code.value });
+      this.setPermalinkParams(this.props.id, code.label);
     }
   }
 

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -32,10 +32,17 @@
 }
 
 .card .country {
+  background: transparent;
+  border: none;
+  cursor: pointer;
   color: hsl(0, 0%, 29%);
   display: flex;
   flex-direction: row;
   align-items: center;
+}
+
+.card .country:hover {
+  color: var(--tag-color);
 }
 
 .card .avatar {

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -96,7 +96,13 @@ const LikeButton = ({ onClick, liked }) => (
   </button>
 );
 
-const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
+const Card = ({
+  mentor,
+  onFavMentor,
+  isFav,
+  handleTagClick,
+  handleCountryClick,
+}) => {
   const toggleFav = () => {
     isFav = !isFav;
     onFavMentor(mentor);
@@ -143,10 +149,13 @@ const Card = ({ mentor, onFavMentor, isFav, handleTagClick }) => {
   const CardHeader = () => {
     return (
       <div className="header">
-        <div className="country location">
+        <button
+          className="country location"
+          onClick={handleCountryClick.bind(null, mentor.country)}
+        >
           <i className={'fa fa-map-marker'} />
           <p>{mentor.country}</p>
-        </div>
+        </button>
 
         <Avatar mentor={mentor} id={mentorId} />
         <LikeButton onClick={toggleFav} liked={isFav} />

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -75,7 +75,7 @@ export default class Filter extends Component {
               id="country"
               source={countries}
               onSelect={this.onCountrySelect}
-              clickedTag={clickedCountry}
+              clickedCountry={clickedCountry}
             />
           </Input>
           <Input id="name" label="Name" key="name">

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -41,7 +41,7 @@ export default class Filter extends Component {
   };
 
   render() {
-    const { onToggleSwitch, clickedTag } = this.props;
+    const { onToggleSwitch, clickedTag, clickedCountry } = this.props;
     const { showFilters } = this.state;
 
     return (
@@ -75,6 +75,7 @@ export default class Filter extends Component {
               id="country"
               source={countries}
               onSelect={this.onCountrySelect}
+              clickedTag={clickedCountry}
             />
           </Input>
           <Input id="name" label="Name" key="name">

--- a/src/components/MentorsList/MentorsList.js
+++ b/src/components/MentorsList/MentorsList.js
@@ -34,6 +34,7 @@ export default class MentorsLists extends Component {
       favorites,
       onFavMentor,
       handleTagClick,
+      handleCountryClick,
     } = this.props;
     const { page } = this.state;
 
@@ -53,6 +54,7 @@ export default class MentorsLists extends Component {
               onFavMentor={onFavMentor}
               isFav={favorites.indexOf(mentor.id) > -1}
               handleTagClick={handleTagClick}
+              handleCountryClick={handleCountryClick}
             />
           ))}
           {mentorsInList.length === 0 && (


### PR DESCRIPTION
I took a shot at implementing the feature to click the country icons in mentor cards.

I mainly took inspiration from the implementation of language tags. Happy to hear what you think.
It might be worth in the future to add hover, focus states and other accessibility features throughout the code base. 

Closes #370 