### PR TITLE
add new photo URL

### DIFF
--- a/src/mentors.json
+++ b/src/mentors.json
@@ -6032,7 +6032,7 @@
   {
     "id": "mannuel@themwebs.me",
     "name": "Mannuel Ferreira",
-    "avatar": "https://themwebs.me/images/mannuel_ferreira_web.jpg",
+    "avatar": "https://themwebs.me/website/wp-content/uploads/2019/04/mannuel_ferreira_web.jpg",
     "title": "Software Engineer",
     "description": "I'm an engineer specialising in front end. Happy to help.",
     "country": "ZA",


### PR DESCRIPTION
My other URL was 403 Forbidden.

This should fix it.

![Screenshot 2019-04-30 at 10 54 21](https://user-images.githubusercontent.com/210504/56950753-824cfb80-6b36-11e9-909a-b2add525b314.png)
