### PR TITLE
removes "git pull" step from user-add script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Just go to https://mentors.codingcoach.io/ and find her / him / them.
 ## Want to be a mentor?
 
 1. Fork
+1. Clone your fork (if you use passphrase, please clone with the HTTPS approach)
 1. `yarn` (make sure you have a compatible node version, [nvm](https://github.com/creationix/nvm) or [fnm](https://github.com/Schniz/fnm#installation) can help here)
 
 ### CLI Geek?

--- a/scripts/add-mentor.js
+++ b/scripts/add-mentor.js
@@ -10,9 +10,6 @@ const Ora = require('ora');
 
 const createUser = require('./create-user');
 
-const spinnerPull = new Ora({
-  text: 'Retrieving most recent changes',
-});
 const spinnerMerge = new Ora({
   text: 'Adding to mentors list',
 });
@@ -25,10 +22,6 @@ const spinnerCommit = new Ora({
 const spinnerPush = new Ora({
   text: 'Publishing to Github',
 });
-
-async function gitPull() {
-  await execa('git', ['pull']);
-}
 
 async function gitBranch(name) {
   await execa('git', ['checkout', '-b', `add-${name}-as-mentor`]);
@@ -49,17 +42,6 @@ async function gitPush(name) {
 }
 
 const gitFunctions = {
-  pullProcess: async () => {
-    spinnerPull.start();
-    try {
-      await gitPull();
-      spinnerPull.succeed();
-    } catch (error) {
-      spinnerPull.fail();
-      console.error('\x1b[31m%s\x1b[0m', 'Error: ' + error.message);
-      throw new Error('There is a problem with the git pull process');
-    }
-  },
   branchProcess: async answers => {
     spinnerBranch.start();
     try {
@@ -117,7 +99,6 @@ async function addToMentorsList(mentor) {
 
 (async () => {
   try {
-    await gitFunctions.pullProcess();
     const answers = await createUser();
     await addToMentorsList(answers);
     await gitFunctions.branchProcess(answers);


### PR DESCRIPTION
First time I had run ```yarn run add-user``` it started an infinite loop waiting for the GitHub repository password (password request didn't display).

Calling git pull synchronously allowed me to enter the password and "git pull" my fork:
```js
await execa.sync('git', ['pull']);
```

So I tried it on Windows, and I'm not able to run the same command or similar without some workarounds and OS verification.

To avoid these workarounds and OS verification that will increase the script complexity, I would like to suggest to remove the `git pull` call from the add-user script.