### PR TITLE
293 language autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Just go to https://mentors.codingcoach.io/ and find her / him / them.
   "title": "NodeJS developer",                  // minLength: 2, maxLength: 30
   "description": "Hi, I'm NodeJs developer",    // minLength: 5, maxLength: 80 optional
   "country": "SE",                              // Country code (link to the list below)
+  "spokenLanguages": [                          // ISO language code (link to list below)
+    "en", "fr", "zh"
+  ],
   "tags": [                                     // minItems: 1, maxItems: 5, only lowercase characters
     "nodejs", "webpack", "mongodb"              // please avoid synonyms (see list below)
   ],
@@ -81,6 +84,9 @@ Just go to https://mentors.codingcoach.io/ and find her / him / them.
 #### Country codes
 
 https://github.com/hjnilsson/country-flags/blob/master/countries.json
+
+#### Spoken language ISO codes
+https://github.com/meikidd/iso-639-1/blob/master/src/data.js
 
 #### Channels
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "classnames": "^2.2.6",
     "express": "^4.16.4",
     "inquirer-autocomplete-prompt": "^1.0.1",
+    "inquirer-checkbox-plus-prompt": "^1.0.1",
     "iso-639-1": "^2.0.5",
     "lodash": "^4.17.11",
     "react": "^16.7.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "classnames": "^2.2.6",
     "express": "^4.16.4",
     "inquirer-autocomplete-prompt": "^1.0.1",
+    "iso-639-1": "^2.0.5",
     "lodash": "^4.17.11",
     "react": "^16.7.0",
     "react-aria-offcanvas": "^1.1.10",

--- a/scripts/create-user.js
+++ b/scripts/create-user.js
@@ -1,6 +1,7 @@
 'use strict';
 const inquirer = require('inquirer');
 const countries = require('svg-country-flags/countries.json');
+const ISO6391 = require('iso-639-1');
 const checkSynonyms = require('../src/checkSynonymsTags');
 const https = require('https');
 var imageType = require('image-type');
@@ -9,6 +10,11 @@ var imageType = require('image-type');
 inquirer.registerPrompt(
   'autocomplete',
   require('inquirer-autocomplete-prompt')
+);
+
+inquirer.registerPrompt(
+  'checkbox-plus',
+  require('inquirer-checkbox-plus-prompt')
 );
 
 function validateEmail(value) {
@@ -113,6 +119,22 @@ const questionCountry = {
       .filter(country => country.toLowerCase().startsWith(input.toLowerCase()))
       .sort(),
 };
+
+const questionSpokenLanguages = {
+  type: 'checkbox-plus',
+  name: 'languages',
+  message: 'Please add your spoken languages: (type to search, use space to select multiple languages, enter to submit)',
+  pageSize: 10,
+  highlight: true,
+  searchable: true,
+  default: ['English'],
+  source: async (answers, input) => {
+     input = input || ''
+     var data = ISO6391.getAllNames()
+     var results = data.filter(language => language.toLowerCase().startsWith(input.toLowerCase()))
+     return results
+  }
+}
 
 function validateTags(value) {
   const hasSynonymsErrors = tags => {
@@ -252,6 +274,7 @@ const questions = [
   questionTitle,
   questionDescription,
   questionCountry,
+  questionSpokenLanguages,
   questionTags,
   questionChannels,
   questionByChannel.email,
@@ -292,6 +315,8 @@ function convertAnswersToSchema(answers) {
         }
       });
       delete answers[answer];
+    } else if (answer === 'spokenLanguages') {
+      answers[answer] = answers[answer].map((answer) => ISO6391.getCode(answer))
     }
   }
   return answers;

--- a/scripts/create-user.js
+++ b/scripts/create-user.js
@@ -122,7 +122,7 @@ const questionCountry = {
 
 const questionSpokenLanguages = {
   type: 'checkbox-plus',
-  name: 'languages',
+  name: 'spokenLanguages',
   message: 'Please add your spoken languages: (type to search, use space to select multiple languages, enter to submit)',
   pageSize: 10,
   highlight: true,

--- a/scripts/pre-build.js
+++ b/scripts/pre-build.js
@@ -2,19 +2,22 @@ const fs = require('fs');
 
 const mentors = require('../src/mentors.json');
 const json = {
-  language: [],
+  technology: [],
   country: [],
   name: [],
+  language: [],
 };
 
 for (let i = 0; i < mentors.length; i++) {
-  json.language.push(...(mentors[i].tags || []));
+  json.technology.push(...(mentors[i].tags || []));
   json.country.push(mentors[i].country);
   json.name.push(mentors[i].name);
+  json.language.push(...(mentors[i].spokenLanguages || []));
 }
 
-json.language = [...new Set(json.language)];
+json.technology = [...new Set(json.technology)];
 json.country = [...new Set(json.country)];
+json.language = [...new Set(json.language)];
 
 const breaklink = '\n\t';
 const createUrl = (key, value) =>

--- a/src/__tests__/mentors.json-test.js
+++ b/src/__tests__/mentors.json-test.js
@@ -2,6 +2,7 @@ import mentors from '../mentors.json';
 import Ajv from 'ajv';
 import { get as getPath } from 'object-path';
 import countries from 'svg-country-flags/countries.json';
+import ISO6391 from 'iso-639-1'
 import _ from 'lodash';
 import checkSynonyms from '../checkSynonymsTags';
 
@@ -124,6 +125,14 @@ const mentorSchema = {
       country: {
         type: 'string',
         enum: Object.keys(countries),
+      },
+      spokenLanguages: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          type: 'string',
+          enum: ISO6391.getAllCodes(),
+        },
       },
       tags: {
         type: 'array',

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -50,12 +50,21 @@ class App extends Component {
     window.ga('send', 'event', 'Filter', 'name', 'name');
   };
 
+  handleLanguageSelect = async ({ value: language }) => {
+    await scrollToTop();
+    this.setState({
+      language,
+    });
+    window.ga('send', 'event', 'Filter', 'language', language);
+  }
+
   filterMentors = mentor => {
-    const { tag, country, name, showFavorite, favorites } = this.state;
+    const { tag, country, name, language, showFavorite, favorites } = this.state;
     return (
       (!tag || mentor.tags.includes(tag)) &&
       (!country || mentor.country === country) &&
       (!name || mentor.name === name) &&
+      (!language || (mentor.spokenLanguages && mentor.spokenLanguages.includes(language))) &&
       (!showFavorite || favorites.indexOf(mentor.id) > -1)
     );
   };
@@ -97,6 +106,7 @@ class App extends Component {
       tag: permalink.get('technology'),
       country: permalink.get('country'),
       name: permalink.get('name'),
+      language: permalink.get('language')
     });
   }
 
@@ -142,6 +152,7 @@ class App extends Component {
               onTagSelected={this.handleTagSelect}
               onCountrySelected={this.handleCountrySelect}
               onNameSelected={this.handleNameSelect}
+              onLanguageSelected={this.handleLanguageSelect}
               onToggleFilter={this.toggleFields}
               onToggleSwitch={this.toggleSwitch}
               mentorCount={mentorsInList.length}

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -8,13 +8,14 @@ import Input from '../Input/Input';
 import Switch from '../Switch/Switch';
 
 import { generateLists } from '../../listsGenerator';
-const { tags, countries, names } = generateLists(mentors);
+const { tags, countries, names, languages } = generateLists(mentors);
 
 export default class Filter extends Component {
   state = {
     tag: '',
     country: '',
     name: '',
+    language: '',
     showFilters: false,
   };
 
@@ -31,6 +32,11 @@ export default class Filter extends Component {
   onNameSelect = name => {
     this.setState({ name });
     this.props.onNameSelected(name);
+  };
+
+  onLanguageSelect = language => {
+    this.setState({ language });
+    this.props.onLanguageSelected(language);
   };
 
   onToggleFilter = () => {
@@ -82,6 +88,13 @@ export default class Filter extends Component {
               id="name"
               source={names}
               onSelect={this.onNameSelect}
+            />
+          </Input>
+          <Input id="language" label="Language" key="language">
+            <AutoComplete
+              id="language"
+              source={languages}
+              onSelect={this.onLanguageSelect}
             />
           </Input>
           <Switch id="fav" label="My Favorites" onToggle={onToggleSwitch} />

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -62,9 +62,9 @@ export default class Filter extends Component {
           </button>
         </h3>
         <div className="inputs" aria-expanded={showFilters}>
-          <Input id="language" label="Language or technology" key="language">
+          <Input id="technology" label="Technology" key="technology">
             <AutoComplete
-              id="language"
+              id="technology"
               source={tags}
               onSelect={this.onTagSelect}
               clickedTag={clickedTag}

--- a/src/listsGenerator.js
+++ b/src/listsGenerator.js
@@ -1,4 +1,5 @@
 import countries from 'svg-country-flags/countries.json';
+import ISO6391 from 'iso-639-1/src/index';
 
 function mapToItem(label, value) {
   return {
@@ -16,12 +17,14 @@ export function generateLists(mentors) {
     tags: [],
     countries: [],
     names: [],
+    languages: [],
   };
 
   for (let i = 0; i < mentors.length; i++) {
     json.tags.push(...(mentors[i].tags || []));
     json.countries.push(mentors[i].country);
     json.names.push(mentors[i].name);
+    json.languages.push(...(mentors[i].spokenLanguages || []));
   }
 
   json.names = [...new Set(json.names)].map(mapToItem).sort(sortByLabel);
@@ -31,6 +34,8 @@ export function generateLists(mentors) {
   json.countries = [...new Set(json.countries)]
     .map(country => mapToItem(countries[country], country))
     .sort(sortByLabel);
-
+  json.languages = [...new Set(json.languages)]
+    .map(language => mapToItem(ISO6391.getName(language), language))
+    .sort(sortByLabel)
   return json;
 }

--- a/src/listsGenerator.js
+++ b/src/listsGenerator.js
@@ -1,5 +1,5 @@
 import countries from 'svg-country-flags/countries.json';
-import ISO6391 from 'iso-639-1/src/index';
+import ISO6391 from 'iso-639-1';
 
 function mapToItem(label, value) {
   return {

--- a/src/titleGenerator.js
+++ b/src/titleGenerator.js
@@ -1,19 +1,23 @@
 import countries from 'svg-country-flags/countries.json';
+import ISO6391 from 'iso-639-1'
 
 export const prefix = 'Coding Coach';
 
-export function set({ tag, country, name }) {
-  document.title = generate({ tag, country, name });
+export function set({ tag, country, name, language }) {
+  document.title = generate({ tag, country, name, language });
 }
 
-export function generate({ tag, country, name }) {
+export function generate({ tag, country, name, language }) {
   let title = prefix;
-  if (name || country || tag) {
+  if (name || country || tag || language) {
     title += ' | ';
 
     if (name) {
       title += name;
     } else {
+      if (language) {
+        title += ` ${ISO6391.getName(language)} speaking `
+      }
       if (tag) {
         title += `${tag} `;
       }


### PR DESCRIPTION
resolves #293 
Adds language autocomplete to filter sidebar, updates mentor schema and manual instructions, and adds cli question with a searchable checkbox. 

Should languages be added to the required fields in the mentor schema? I left it out and used the logic in the `filterMentors` function in `app.js` for backwards compatibility. English is selected/added as a default going forward. Alternatively, the current `mentors.json` can be updated so each mentor has it as a default and the extra check in filter mentors can be removed, but i'm unsure how to do this. 
