### PR TITLE
prevent autocomplete

### DIFF
--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -5,7 +5,7 @@ import Autocomplete from 'react-autocomplete';
 import classNames from 'classnames';
 
 function renderInput(props) {
-  return <input {...props} className="input" />;
+  return <input {...props} className="input" autoComplete="off" />;
 }
 
 function renderItem(item, isHighlighted) {
@@ -95,7 +95,9 @@ export default class AutoComplete extends Component {
 
   render() {
     const { value } = this.state;
-    const { id, source } = this.props;
+    const { source } = this.props;
+    let { id } = this.props;
+    id = `${id}-${Math.random()}`;
 
     return (
       <div className="ac">


### PR DESCRIPTION
As shown below, the autocomplete functionality of the browser is really disruptive to filtering, one case (Language) it takes very little for the autocomplete to completely obscure the underlying dropdown.  

It did not seem like the intention was to allow browser-based autocompletion in this filtering, so I've cut a PR to turn it off.

![image](https://cl.ly/33cb374ed9f6/Screen%20Recording%202019-05-05%20at%2005.51%20PM.gif)