### PR TITLE
Fix #428: Added PUBLIC_URL and NODE_ENV to be injected during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ script:
   - yarn test
   - yarn predeploy
 env:
-  - PUBLIC_URL=https://mentors.codingcoach.io
-  - NODE_ENV=production
+  - PUBLIC_URL=https://mentors.codingcoach.io NODE_ENV=production
+
 deploy:
   provider: pages
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ cache:
   - "$HOME/.yarn-cache"
 script:
   - yarn test
-  - yarn predeploy
+  - NODE_ENV=production yarn predeploy
 env:
-  - PUBLIC_URL=https://mentors.codingcoach.io NODE_ENV=production
-
+  - PUBLIC_URL=https://mentors.codingcoach.io 
 deploy:
   provider: pages
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ cache:
 script:
   - yarn test
   - yarn predeploy
+env:
+  - PUBLIC_URL=https://mentors.codingcoach.io
+  - NODE_ENV=production
 deploy:
   provider: pages
   skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -60,6 +60,5 @@
     "prettier": "1.16.4",
     "start-server-and-test": "^1.9.0"
   },
-  "homepage": "https://mentors.codingcoach.io",
   "license": "MIT"
 }


### PR DESCRIPTION
It looks like the build process is not replacing the `%PUBLIC_URL%` hence the meta tags are not created with absolute URLs.

%PUBLIC_URL% in `public/index.html` will get replaced during build
only if the NODE_ENV is set to production.
Setting the `PUBLIC_URL` will ensure that all meta tags are created
correctly for Social Media Sharing and previews.

resolve #428