### PR TITLE
Issue #478 Unused `name` param in Cypress Support Commands

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,5 +1,5 @@
 Cypress.Commands.add('filterByName', name => {
   cy.getByTestId('name-filter-autocomplete')
-    .type('Brent M Clark')
+    .type(name)
     .type('{enter}');
 });


### PR DESCRIPTION
What this PR does:
 * Now `name` param passed to the `filterByName` method is used

Resolve #478 