### PR TITLE
Issue 498 clear btn on autocomplete filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.history/
 
 npm-debug.log*
 yarn-debug.log*

--- a/cypress/integration/mentors.js
+++ b/cypress/integration/mentors.js
@@ -43,5 +43,5 @@ describe('Mentor Filtering', () => {
       .filterByName('Brent M Clark')
       .getByTestId('clear-filter')
       .should('have.length', 1);
-  })
+  });
 });

--- a/cypress/integration/mentors.js
+++ b/cypress/integration/mentors.js
@@ -37,4 +37,11 @@ describe('Mentor Filtering', () => {
       .getByTestId('mentor-card')
       .should('have.length', 1);
   });
+
+  it('can clear filter', () => {
+    cy.visit('/')
+      .filterByName('Brent M Clark')
+      .getByTestId('clear-filter')
+      .should('have.length', 1);
+  })
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,5 +1,5 @@
 Cypress.Commands.add('filterByName', name => {
   cy.getByTestId('name-filter-autocomplete')
-    .type('Brent M Clark')
+    .type(name)
     .type('{enter}');
 });

--- a/src/components/AutoComplete/AutoComplete.css
+++ b/src/components/AutoComplete/AutoComplete.css
@@ -14,9 +14,18 @@
   border-top: 0;
 }
 
+.ac .clear-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
 @media all and (max-width: 576px) {
   .ac .ac-menu {
     width: calc(100% - var(--filter-input-offset) * 2);
+  }
+  .ac .clear-btn {
+    right: 35px;
   }
 }
 

--- a/src/components/AutoComplete/AutoComplete.css
+++ b/src/components/AutoComplete/AutoComplete.css
@@ -16,7 +16,7 @@
 
 .ac .clear-btn {
   position: absolute;
-  top: 10px;
+  top: 50%;
   right: 10px;
 }
 

--- a/src/components/AutoComplete/AutoComplete.css
+++ b/src/components/AutoComplete/AutoComplete.css
@@ -18,6 +18,7 @@
   position: absolute;
   top: 50%;
   right: 10px;
+  transform: translateY(-50%);
 }
 
 @media all and (max-width: 576px) {

--- a/src/components/AutoComplete/AutoComplete.css
+++ b/src/components/AutoComplete/AutoComplete.css
@@ -25,7 +25,7 @@
     width: calc(100% - var(--filter-input-offset) * 2);
   }
   .ac .clear-btn {
-    right: 35px;
+    right: 20px;
   }
 }
 

--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -100,7 +100,7 @@ export default class AutoComplete extends Component {
 
   render() {
     const { value } = this.state;
-    const { clearButton, source, 'data-testid': testid } = this.props;
+    const { showClear, source, 'data-testid': testid } = this.props;
     let { id } = this.props;
     id = `${id}-${Math.random()}`;
 
@@ -122,7 +122,7 @@ export default class AutoComplete extends Component {
             'data-testid': testid,
           }}
         />
-        {clearButton && value && (
+        {showClear && value && (
           <div className={'clear-btn'}>
             <FilterClear onClear={this.onClear} />
           </div>

--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -100,7 +100,7 @@ export default class AutoComplete extends Component {
 
   render() {
     const { value } = this.state;
-    const { source, 'data-testid': testid } = this.props;
+    const { clearButton, source, 'data-testid': testid } = this.props;
     let { id } = this.props;
     id = `${id}-${Math.random()}`;
 
@@ -122,7 +122,7 @@ export default class AutoComplete extends Component {
             'data-testid': testid,
           }}
         />
-        {value && (
+        {clearButton && value && (
           <div className={'clear-btn'}>
             <FilterClear onClear={this.onClear} />
           </div>

--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -3,6 +3,7 @@ import './AutoComplete.css';
 import React, { Component } from 'react';
 import Autocomplete from 'react-autocomplete';
 import classNames from 'classnames';
+import FilterClear from '../FilterClear/FilterClear';
 
 function renderInput(props) {
   return <input {...props} className="input" autoComplete="off" />;
@@ -40,6 +41,10 @@ export default class AutoComplete extends Component {
       this.props.onSelect({ value: '', label: '' });
     }
     this.setPermalinkParams(this.props.id, value);
+  };
+
+  onClear = event => {
+    this.onChange(event, '');
   };
 
   matchStateToTerm(state, value) {
@@ -117,6 +122,11 @@ export default class AutoComplete extends Component {
             'data-testid': testid,
           }}
         />
+        {value && (
+          <div className={'clear-btn'}>
+            <FilterClear onClear={this.onClear} />
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -74,6 +74,7 @@ export default class Filter extends Component {
               source={tags}
               onSelect={this.onTagSelect}
               clickedTag={clickedTag}
+              clearButton={true}
               data-testid="technology-filter-autocomplete"
             />
           </Input>
@@ -83,6 +84,7 @@ export default class Filter extends Component {
               source={countries}
               onSelect={this.onCountrySelect}
               clickedCountry={clickedCountry}
+              clearButton={true}
               data-testid="country-filter-autocomplete"
             />
           </Input>
@@ -91,6 +93,7 @@ export default class Filter extends Component {
               id="name"
               source={names}
               onSelect={this.onNameSelect}
+              clearButton={true}
               data-testid="name-filter-autocomplete"
             />
           </Input>
@@ -99,6 +102,7 @@ export default class Filter extends Component {
               id="language"
               source={languages}
               onSelect={this.onLanguageSelect}
+              clearButton={true}
               data-testid="language-filter-autocomplete"
             />
           </Input>

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -74,7 +74,7 @@ export default class Filter extends Component {
               source={tags}
               onSelect={this.onTagSelect}
               clickedTag={clickedTag}
-              clearButton
+              showClear
               data-testid="technology-filter-autocomplete"
             />
           </Input>
@@ -84,7 +84,7 @@ export default class Filter extends Component {
               source={countries}
               onSelect={this.onCountrySelect}
               clickedCountry={clickedCountry}
-              clearButton
+              showClear
               data-testid="country-filter-autocomplete"
             />
           </Input>
@@ -93,7 +93,7 @@ export default class Filter extends Component {
               id="name"
               source={names}
               onSelect={this.onNameSelect}
-              clearButton
+              showClear
               data-testid="name-filter-autocomplete"
             />
           </Input>
@@ -102,7 +102,7 @@ export default class Filter extends Component {
               id="language"
               source={languages}
               onSelect={this.onLanguageSelect}
-              clearButton
+              showClear
               data-testid="language-filter-autocomplete"
             />
           </Input>

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -74,7 +74,7 @@ export default class Filter extends Component {
               source={tags}
               onSelect={this.onTagSelect}
               clickedTag={clickedTag}
-              clearButton={true}
+              clearButton
               data-testid="technology-filter-autocomplete"
             />
           </Input>
@@ -84,7 +84,7 @@ export default class Filter extends Component {
               source={countries}
               onSelect={this.onCountrySelect}
               clickedCountry={clickedCountry}
-              clearButton={true}
+              clearButton
               data-testid="country-filter-autocomplete"
             />
           </Input>
@@ -93,7 +93,7 @@ export default class Filter extends Component {
               id="name"
               source={names}
               onSelect={this.onNameSelect}
-              clearButton={true}
+              clearButton
               data-testid="name-filter-autocomplete"
             />
           </Input>
@@ -102,7 +102,7 @@ export default class Filter extends Component {
               id="language"
               source={languages}
               onSelect={this.onLanguageSelect}
-              clearButton={true}
+              clearButton
               data-testid="language-filter-autocomplete"
             />
           </Input>

--- a/src/components/FilterClear/FilterClear.css
+++ b/src/components/FilterClear/FilterClear.css
@@ -1,0 +1,9 @@
+.clear {
+  font-size: 12px;
+  padding: 5px;
+}
+
+.clear:hover {
+  color: var(--tag-color);
+  cursor: pointer;
+}

--- a/src/components/FilterClear/FilterClear.css
+++ b/src/components/FilterClear/FilterClear.css
@@ -1,6 +1,8 @@
 .clear {
   font-size: 12px;
   padding: 5px;
+  border: none;
+  background: none;
 }
 
 .clear:hover {

--- a/src/components/FilterClear/FilterClear.js
+++ b/src/components/FilterClear/FilterClear.js
@@ -4,7 +4,7 @@ import './FilterClear.css';
 const FilterClear = ({ onClear }) => {
   return (
     <>
-      <span className="clear" data-testid="clear-filter" onClick={onClear}>
+      <button className="clear" data-testid="clear-filter" onClick={onClear}>
         clear
       </span>
     </>

--- a/src/components/FilterClear/FilterClear.js
+++ b/src/components/FilterClear/FilterClear.js
@@ -4,7 +4,9 @@ import './FilterClear.css';
 const FilterClear = ({ onClear }) => {
   return (
     <>
-      <span className='clear' data-testid="clear-filter" onClick={onClear}>clear</span>
+      <span className="clear" data-testid="clear-filter" onClick={onClear}>
+        clear
+      </span>
     </>
   );
 };

--- a/src/components/FilterClear/FilterClear.js
+++ b/src/components/FilterClear/FilterClear.js
@@ -3,9 +3,9 @@ import './FilterClear.css';
 
 const FilterClear = ({ onClear }) => {
   return (
-    <React.Fragment>
-      <span className='clear' onClick={onClear}>clear</span>
-    </React.Fragment>
+    <>
+      <span className='clear' data-testid="clear-filter" onClick={onClear}>clear</span>
+    </>
   );
 };
 

--- a/src/components/FilterClear/FilterClear.js
+++ b/src/components/FilterClear/FilterClear.js
@@ -6,7 +6,7 @@ const FilterClear = ({ onClear }) => {
     <>
       <button className="clear" data-testid="clear-filter" onClick={onClear}>
         clear
-      </span>
+      </button>
     </>
   );
 };

--- a/src/components/FilterClear/FilterClear.js
+++ b/src/components/FilterClear/FilterClear.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './FilterClear.css';
+
+const FilterClear = ({ onClear }) => {
+  return (
+    <React.Fragment>
+      <span className='clear' onClick={onClear}>clear</span>
+    </React.Fragment>
+  );
+};
+
+export default FilterClear;


### PR DESCRIPTION
What this PR does:
Resolve: #498 
Added a clear button/icon at the right of the autocomplete filter, when it is clicked, the autocomplete input is cleared.

This "clear" button is optional, because we can reuse the autocomplete in another places where we don't need to clear the value by default.

How to test
 * Just add some filters. It should looks like this picture:
![image](https://user-images.githubusercontent.com/236566/61486312-8ccea280-a979-11e9-9656-b1a3b2176f78.png)

TODO:
[ ] Implement tests