### PR TITLE
Typo fix for tags help text

### DIFF
--- a/src/components/MemberArea/model.js
+++ b/src/components/MemberArea/model.js
@@ -81,7 +81,7 @@ export default {
     },
     options: tags.map(tag => ({ value: tag, label: tag })),
     validate: options => !!options.length,
-    helpText: 'Up tp 5',
+    helpText: 'Up to 5',
   },
   channels: {
     label: 'Channels',


### PR DESCRIPTION
It reads Up tp 5 on the site right now, this commit fixes that.