### PR TITLE
Fix/Add input validation to the Linkedin channel field

### DIFF
--- a/src/components/MemberArea/model.js
+++ b/src/components/MemberArea/model.js
@@ -100,7 +100,7 @@ export default {
         value: 'linkedin',
         label: 'LinkedIn',
         prefix: 'https://linkedin.com/in/',
-        validate: value => !!value && linkedinValidation(value),
+        validate: value => linkedinValidation(value),
       },
       { value: 'facebook', label: 'Facebook', prefix: 'https://facebook.com/' },
       { value: 'twitter', label: 'Twitter', prefix: 'https://twitter.com/@' },

--- a/src/components/MemberArea/model.js
+++ b/src/components/MemberArea/model.js
@@ -6,9 +6,11 @@ import tags from './tags';
 const languages = ISO6391.getLanguages(ISO6391.getAllCodes());
 const emailPattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 const urlPattern = /^https:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/;
+const linkedinPattern = /^[A-Za-z0-9-]{3,100}$/;
 
 const emailValidation = value => !value || emailPattern.test(value);
 const urlValidation = value => !value || urlPattern.test(value);
+const linkedinValidation = value => !value || linkedinPattern.test(value);
 
 export default {
   email: {
@@ -98,6 +100,7 @@ export default {
         value: 'linkedin',
         label: 'LinkedIn',
         prefix: 'https://linkedin.com/in/',
+        validate: value => !!value && linkedinValidation(value),
       },
       { value: 'facebook', label: 'Facebook', prefix: 'https://facebook.com/' },
       { value: 'twitter', label: 'Twitter', prefix: 'https://twitter.com/@' },


### PR DESCRIPTION
The issue was that members could add invalid syntax to the linkedin
input field that would cause the link to be invalid. This PR adds
a REGEX pattern that does input validation.

For the input to be valid it must contain the following according
to Linkedin.

* 3 - 100 letters or numbers (capital letters are allowed)
* No spaces, symbols or special characters (except hyphen which is allowed)

fixes #592