### PR TITLE
Add Quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Forking the project will create a copy of that project in your own GitHub accoun
 #### Quick start
 
 1. Navigate to the project folder.
-2. Run `yarn install`
+2. Run `yarn`
 3. Run `yarn test`
 4. Type `a` to run all tests
 5. Type `q` to quit (this will start cypress and set that up)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Forking the project will create a copy of that project in your own GitHub accoun
 3. Run `yarn test`
 4. Type `a` to run all tests
 5. Type `q` to quit (this will start cypress and set that up)
-6. Navigate to [http://localhost:3000](http://localhost:3000) to see the site
+6. If the browser doesn't open automatically, navigate to [http://localhost:3000](http://localhost:3000) to see the site.
 
 For other options, please see [Available Scripts](https://github.com/Coding-Coach/find-a-mentor#available-scripts) below.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Forking the project will create a copy of that project in your own GitHub accoun
 5. Type `q` to quit (this will start cypress and set that up)
 6. Navigate to [http://localhost:3000](http://localhost:3000) to see the site
 
-For other options, please see "Available Scripts" below.
+For other options, please see [Available Scripts](https://github.com/Coding-Coach/find-a-mentor#available-scripts) below.
 
 #### Updating your local
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ This section describes the workflow we are going to follow when working in a new
 
 Forking the project will create a copy of that project in your own GitHub account, you will commit your work against your own repository.
 
+#### Quick start
+
+1. Navigate to the project folder.
+2. Run `npm install`
+3. Run `yarn test`
+4. Type `a` to run all tests
+5. Type `q` to quit (this will start cypress and set that up)
+6. Navigate to [http://localhost:3000](http://localhost:3000) to see the site
+
 #### Updating your local
 
 In order to update your local environment to the latest version on `master`, you will have to pull the changes using the `upstream` repository, for example: `git pull upstream master`. This will pull all the new commits from the origin repository to your local environment.

--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ Forking the project will create a copy of that project in your own GitHub accoun
 #### Quick start
 
 1. Navigate to the project folder.
-2. Run `npm install`
+2. Run `yarn install`
 3. Run `yarn test`
 4. Type `a` to run all tests
 5. Type `q` to quit (this will start cypress and set that up)
 6. Navigate to [http://localhost:3000](http://localhost:3000) to see the site
+
+For other options, please see "Available Scripts" below.
 
 #### Updating your local
 


### PR DESCRIPTION

As an experienced developer, I found I missed the `npm install` step
when setting up my development environment for the first time. I added a
Quick start section under Workflow to reduce time-to-success for
newcomers to the project.