### PR TITLE
Fix #629: Add validations for facebook, Github and Twitter username

### DIFF
--- a/src/components/MemberArea/EditProfile.css
+++ b/src/components/MemberArea/EditProfile.css
@@ -132,6 +132,11 @@
   margin: 5px 0;
 }
 
+.edit-profile .form-field .helper-text {
+  color: #aaa;
+  font-style: italic;
+}
+
 @media all and (max-width: 800px) {
   .edit-profile .form-fields {
     margin: 0;

--- a/src/components/MemberArea/EditProfile.js
+++ b/src/components/MemberArea/EditProfile.js
@@ -236,7 +236,7 @@ export default class EditProfile extends Component {
                           }
                         />
                       </div>
-                      {option.helpText && <div>{option.helpText}</div>}
+                      {option.helpText && <div class="helper-text">{option.helpText}</div>}
                     </div>
                   );
                 })}

--- a/src/components/MemberArea/model.js
+++ b/src/components/MemberArea/model.js
@@ -104,38 +104,38 @@ export default {
         validate: emailValidation,
       },
       {
+        value: 'website',
+        label: 'Website',
+        prefix: 'https://',
+        validate: value => urlValidation(`https://${value}`),
+      },
+      {
         value: 'linkedin',
         label: 'LinkedIn',
         prefix: 'https://linkedin.com/in/',
         validate: value => linkedinValidation(value),
-        helpText: <span class="helper-text">Add only your linkedin username</span>
+        helpText: "Add only your Linkedin username"
       },
       {
         value: 'facebook',
         label: 'Facebook',
         prefix: 'https://facebook.com/',
         validate: value => facebookValidation(value),
-        helpText: <span class="helper-text">Add only your facebook username</span>
+        helpText: "Add only your Facebook username"
       },
       {
         value: 'twitter',
         label: 'Twitter',
         prefix: 'https://twitter.com/',
         validate: value => twitterValidation(value),
-        helpText: <span class="helper-text">Add only your twitter handle</span>
+        helpText: "Add only your Twitter handle"
       },
       {
         value: 'github',
         label: 'Github',
         prefix: 'https://github.com/',
         validate: value => githubValidation(value),
-        helpText: <span class="helper-text">Add only your github username</span>
-      },
-      {
-        value: 'website',
-        label: 'Website',
-        prefix: 'https://',
-        validate: value => urlValidation(`https://${value}`),
+        helpText: "Add only your Github username"
       },
       {
         value: 'slack',

--- a/src/components/MemberArea/model.js
+++ b/src/components/MemberArea/model.js
@@ -7,10 +7,16 @@ const languages = ISO6391.getLanguages(ISO6391.getAllCodes());
 const emailPattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 const urlPattern = /^https:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/;
 const linkedinPattern = /^[A-Za-z0-9-]{3,100}$/;
+const facebookPattern = /^[a-z\d.]{5,50}$/i;
+const twitterPattern = /^[A-Za-z0-9_]{1,15}$/;
+const githubPattern = /^([a-z\d]+-)*[a-z\d]+$/i;
 
 const emailValidation = value => !value || emailPattern.test(value);
 const urlValidation = value => !value || urlPattern.test(value);
 const linkedinValidation = value => !value || linkedinPattern.test(value);
+const facebookValidation = value => !value || facebookPattern.test(value);
+const twitterValidation = value => !value || twitterPattern.test(value);
+const githubValidation = value => !value || githubPattern.test(value);
 
 export default {
   email: {
@@ -102,10 +108,29 @@ export default {
         label: 'LinkedIn',
         prefix: 'https://linkedin.com/in/',
         validate: value => linkedinValidation(value),
+        helpText: <span class="helper-text">Add only your linkedin username</span>
       },
-      { value: 'facebook', label: 'Facebook', prefix: 'https://facebook.com/' },
-      { value: 'twitter', label: 'Twitter', prefix: 'https://twitter.com/@' },
-      { value: 'github', label: 'Github', prefix: 'https://github.com/' },
+      {
+        value: 'facebook',
+        label: 'Facebook',
+        prefix: 'https://facebook.com/',
+        validate: value => facebookValidation(value),
+        helpText: <span class="helper-text">Add only your facebook username</span>
+      },
+      {
+        value: 'twitter',
+        label: 'Twitter',
+        prefix: 'https://twitter.com/',
+        validate: value => twitterValidation(value),
+        helpText: <span class="helper-text">Add only your twitter handle</span>
+      },
+      {
+        value: 'github',
+        label: 'Github',
+        prefix: 'https://github.com/',
+        validate: value => githubValidation(value),
+        helpText: <span class="helper-text">Add only your github username</span>
+      },
       {
         value: 'website',
         label: 'Website',


### PR DESCRIPTION
This pr validates the input field for facebook, github and twitter. It fixes the issue #629. Here is a screenshot of the updated view with the help text


<img width="925" alt="Screenshot 2019-09-12 at 12 38 04 PM" src="https://user-images.githubusercontent.com/32465536/64791215-4b203980-d56f-11e9-9d05-ea80526d97a0.png">

