### PR TITLE
#646: Filers fields are visible while app is loading

### DIFF
--- a/src/context/filtersContext/FiltersContext.js
+++ b/src/context/filtersContext/FiltersContext.js
@@ -11,18 +11,18 @@ const initialFilters = {
   showFilters: false,
 };
 
-const filterReducer = (_, action) => {
+const filterReducer = (state, action) => {
   switch (action.type) {
     case 'filterTag':
-      return { tag: action.payload };
+      return { ...state, tag: action.payload };
     case 'filterCountry':
-      return { country: action.payload };
+      return { ...state, country: action.payload };
     case 'filterName':
-      return { name: action.payload };
+      return { ...state, name: action.payload };
     case 'filterLanguage':
-      return { language: action.payload };
+      return { ...state, language: action.payload };
     case 'showFilters':
-      return { showFilters: action.payload };
+      return { ...state, showFilters: action.payload };
     default:
       throw new Error('');
   }


### PR DESCRIPTION
The problem was after the execution of first filterReducer action, all the state params were getting assigned with undefined value except the one for which the action was invoked. This was leading to problematic behaviour. 
This fix makes sure that when one of the state params is getting changed, others are kept intact.

resolve #646