### PR TITLE
Overwrite default auth0 name and avatar (Issue #639)

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -63,7 +63,7 @@
   width: var(--avatar-dim);
   height: var(--avatar-dim);
   background: hsl(0, 0%, 100%);
-  color: rgb(155, 155, 155);
+  color: var(--generic-avatar-color);
   border-radius: 50%;
   display: block;
 }

--- a/src/components/MemberArea/EditProfile.css
+++ b/src/components/MemberArea/EditProfile.css
@@ -75,16 +75,26 @@
 }
 
 .edit-profile .form-field-input-wrapper .form-field-preview {
-  position: absolute;
   width: 30px;
   border-radius: 50%;
+}
+
+.edit-profile .form-field-input-wrapper .form-field-preview,
+.edit-profile .form-field-input-wrapper i {
+  position: absolute;
   top: 50%;
   transform: translateY(-50%);
   left: 5px;
 }
 
-.edit-profile .form-field-input-wrapper .form-field-preview + input {
+.edit-profile .form-field-input-wrapper .form-field-preview + input,
+.edit-profile .form-field-input-wrapper i + input {
   padding-left: 40px;
+}
+
+.edit-profile .form-field-input-wrapper i {
+  font-size: 30px;
+  color: var(--generic-avatar-color);
 }
 
 .edit-profile .select__control {

--- a/src/components/MemberArea/EditProfile.js
+++ b/src/components/MemberArea/EditProfile.js
@@ -115,11 +115,15 @@ export default class EditProfile extends Component {
               </div>
               <div className="form-field-input-wrapper">
                 {config.previewImage && (
-                  <img
-                    className="form-field-preview"
-                    src={user[fieldName]}
-                    alt="avatar"
-                  />
+                  user[fieldName]
+                    ? (
+                      <img
+                        className="form-field-preview"
+                        src={user[fieldName]}
+                        alt="avatar"
+                      />
+                    )
+                    : <i className="fa fa-user-circle" />
                 )}
                 <CustomTag
                   maxLength={config.maxLength}

--- a/src/components/MemberArea/model.js
+++ b/src/components/MemberArea/model.js
@@ -17,6 +17,8 @@ const linkedinValidation = value => !value || linkedinPattern.test(value);
 const facebookValidation = value => !value || facebookPattern.test(value);
 const twitterValidation = value => !value || twitterPattern.test(value);
 const githubValidation = value => !value || githubPattern.test(value);
+const nameValidation = value =>
+  value.length > 3 && value.length <= 50 && /^\S+(\s\S+)+$/.test(value);
 
 export default {
   email: {
@@ -32,7 +34,7 @@ export default {
     defaultValue: '',
     maxLength: 50,
     helpText: 'Please use your real name',
-    validate: value => !!value && (value.length > 3 && value.length <= 50),
+    validate: value => !!value && nameValidation(value),
   },
   avatar: {
     label: 'Avatar',

--- a/src/helpers/user.js
+++ b/src/helpers/user.js
@@ -23,7 +23,7 @@ export function fromVMtoM(user) {
 export function fromMtoVM(user) {
   return {
     ...user,
-    ...overwriteProfileDefaults(user),
+    ...(isMentor(user) ? {} : overwriteProfileDefaults(user)),
     country: user.country
       ? { label: countries[user.country], value: user.country }
       : { value: '' },

--- a/src/helpers/user.js
+++ b/src/helpers/user.js
@@ -1,5 +1,6 @@
 import ISO6391 from 'iso-639-1';
 import countries from 'svg-country-flags/countries.json';
+import { overwriteProfileDefaults } from '../utils/overwriteProfileDefaults';
 
 export function isMentor(user) {
   return user && user.roles.includes('Mentor');
@@ -22,6 +23,7 @@ export function fromVMtoM(user) {
 export function fromMtoVM(user) {
   return {
     ...user,
+    ...overwriteProfileDefaults(user),
     country: user.country
       ? { label: countries[user.country], value: user.country }
       : { value: '' },

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,8 @@
   --link-color: #015d3e;
   --success-background: #28a745;
   --error-background: #dc3545;
+
+  --generic-avatar-color: rgb(155, 155, 155);
 }
 
 ::selection {

--- a/src/utils/overwriteProfileDefaults.js
+++ b/src/utils/overwriteProfileDefaults.js
@@ -1,0 +1,8 @@
+export function overwriteProfileDefaults({ email, name, avatar }) {
+  const [emailName] = email.split('@');
+
+  return {
+    name: emailName === name ? '' : name,
+    avatar: avatar.indexOf('auth0') > -1 ? '' : avatar,
+  };
+}


### PR DESCRIPTION
* Created a function that will prevent populating the avatar and name
values when editing a profile if they match the default auth0 values
* Improved the validation function for names to require a space.

Fixes: https://github.com/Coding-Coach/find-a-mentor/issues/639