### PR TITLE
Fix typo in Mentee guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Pre-release version of Coding Coach.
 1. Go to https://mentors.codingcoach.io/
 1. Search for a mentor - use the filters for better matching
 1. Find one or more? Register to get their details.
-1. Reach them out.
+1. Reach out to them.
 
 ## Want to be a mentor?
 


### PR DESCRIPTION
Quick fix to the Readme to change line item "Reach them out" to "Reach out to them" in the mentee guidelines.