### PR TITLE
#686 - Prevent 2 scrollbars when modal is open

### DIFF
--- a/src/Me/Me.js
+++ b/src/Me/Me.js
@@ -8,6 +8,7 @@ import Header from './Header/Header';
 import Navbar from './Navigation/Navbar';
 import Home from './Routes/Home';
 import { desktop } from './styles/shared/devices';
+import {GlobalStyle} from './styles/global';
 
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -20,7 +21,6 @@ const Me = ({ match: { url } }) => {
         <>
           <Navbar />
           <Header />
-          <ToastContainer />
           <Main>
             <Switch>
               <Route path={`${url}/home`}>
@@ -32,6 +32,8 @@ const Me = ({ match: { url } }) => {
       ) : (
         <Redirect to="/" />
       )}
+      <ToastContainer />
+      <GlobalStyle />
     </Container>
   );
 };

--- a/src/Me/styles/global.js
+++ b/src/Me/styles/global.js
@@ -1,0 +1,8 @@
+import {createGlobalStyle} from 'styled-components';
+
+export const GlobalStyle = createGlobalStyle`
+  body {
+    &.has-modal {
+      overflow: hidden;
+    }
+  }`

--- a/src/context/modalContext/ModalContext.jsx
+++ b/src/context/modalContext/ModalContext.jsx
@@ -4,6 +4,8 @@ import {
   useModal as rmhUseModal,
 } from 'react-modal-hook';
 
+const BODY_HAS_CLASS_MODAL = 'has-modal';
+
 export const ModalHookProvider = ({children}) => (
   <ModalProvider>{children}</ModalProvider>
 );
@@ -13,12 +15,22 @@ export const ModalHookProvider = ({children}) => (
  * @param {any[]} [deps]
  */
 export function useModal(modal, deps = null) {
+  const onOpenModal = openModal => () => {
+    document.body.classList.add(BODY_HAS_CLASS_MODAL);
+    openModal();
+  }
+
+  const onCloseModal = closeModal => () => {
+    document.body.classList.remove(BODY_HAS_CLASS_MODAL);
+    closeModal();
+  }
+
   const [openModal, closeModal] = rmhUseModal(() => {
     const {type: ModalComponent, props, key} = modal;
     return (
-      <ModalComponent key={key} {...props} closeModal={closeModal} />
+      <ModalComponent key={key} {...props} closeModal={onCloseModal(closeModal)} />
     );
   }, deps);
 
-  return [openModal, closeModal];
+  return [onOpenModal(openModal), onCloseModal(closeModal)];
 }


### PR DESCRIPTION
Scrollbars come from body and modal container. 

Set body `overflow: hidden` when a modal is open.