### PR TITLE
fix(mentor-details): adjust slack

### DIFF
--- a/src/Me/Modals/EditMentorDetails.js
+++ b/src/Me/Modals/EditMentorDetails.js
@@ -78,6 +78,7 @@ const InputContainer = styled.div`
 
   & input {
     flex: 1;
+    width: 100%;
   }
 `;
 

--- a/src/Me/Modals/model.js
+++ b/src/Me/Modals/model.js
@@ -138,7 +138,7 @@ export default {
       {
         value: 'slack',
         label: 'Slack',
-        prefix: 'https://coding-coach.slack.com/team/',
+        prefix: 'https://codin...ck.com/team/',
         helpText: (
           <a
             target="_blank"


### PR DESCRIPTION
In some devices the Slack channel label breaks into 2 lines and expand the view port

<img width="154" alt="Screen Shot 2020-12-22 at 22 21 39" src="https://user-images.githubusercontent.com/3723951/102929945-30dc4780-44a4-11eb-9c6f-b373a0782e7c.png">
<img width="154" alt="Screen Shot 2020-12-22 at 22 22 24" src="https://user-images.githubusercontent.com/3723951/102929951-346fce80-44a4-11eb-9560-36590761b8e6.png">
