### PR TITLE
add missing dep `prop-types` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "inquirer-checkbox-plus-prompt": "^1.0.1",
     "iso-639-1": "^2.1.3",
     "lodash": "^4.17.19",
+    "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-aria-offcanvas": "^1.3.4",
     "react-autocomplete": "^1.8.1",


### PR DESCRIPTION
Troubleshooting with Bo and we found that `prop-types` is not currently a dependency, but should be as it is imported explicitly - `Button.js`, `List.js`, `ListItem.js`, `Select.js`  

This hasn't broken builds in past, because `prop-types` is currently included via peer deps