### PR TITLE
fix(request-modal): toast server validation errors

### DIFF
--- a/src/Me/Modals/MentorshipReqModals/MentorshipRequest.js
+++ b/src/Me/Modals/MentorshipReqModals/MentorshipRequest.js
@@ -38,6 +38,7 @@ const ErrorMessage = styled.div`
 
 const MentorshipRequest = ({ mentor, closeModal }) => {
   const [confirmed, setConfirmed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [mentorshipRequestDetails, setMentorshipRequestDetails] = useState(
     getMyMentorshipApplication()
   );
@@ -143,12 +144,11 @@ const MentorshipRequest = ({ mentor, closeModal }) => {
 
   const onSubmit = async e => {
     e?.preventDefault();
+    setIsLoading(true);
     if (!validate()) return;
     const success = await applyForMentorship(mentor, mentorshipRequestDetails);
-    if (!success) {
-      closeModal();
-    }
     setConfirmed(success);
+    setIsLoading(false);
   };
 
   return (
@@ -158,6 +158,7 @@ const MentorshipRequest = ({ mentor, closeModal }) => {
       closeModal={closeModal}
       submitLabel="Send Request"
       isValid={errors?.isValid}
+      isLoading={isLoading}
     >
       {confirmed ? (
         <Body>

--- a/src/Me/Modals/Modal.js
+++ b/src/Me/Modals/Modal.js
@@ -147,20 +147,14 @@ export const Modal = ({
   title,
   submitLabel = 'Save',
   center,
-  isValid = true,
   children,
+  isLoading,
 }) => {
   const [state, setState] = useState(false);
-  const [loadingState, setLoadingState] = useState(false);
 
   const save = e => {
-    setLoadingState(isValid);
     onSave(e);
   };
-
-  useEffect(() => {
-    if (!isValid) setLoadingState(isValid);
-  }, [isValid]);
 
   useEffect(() => {
     setState(true);
@@ -193,8 +187,8 @@ export const Modal = ({
                 <Button
                   skin="primary"
                   onClick={save}
-                  isLoading={loadingState}
-                  disabled={loadingState}
+                  isLoading={isLoading}
+                  disabled={isLoading}
                 >
                   {submitLabel}
                 </Button>

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -47,10 +47,13 @@ export async function makeApiCall(path, body, method, jsonous = true) {
     }
     return res;
   } catch (error) {
-    reportError('Api', `${error || 'unknown error'} at ${path}`);
     console.error(error);
+
+    const errorMessage = getErrorMessage(error);
+    reportError('Api', `${errorMessage || 'unknown error'} at ${path}`);
+
     !toast.isActive(API_ERROR_TOAST_ID) &&
-      toast.error(error || messages.GENERIC_ERROR, {
+      toast.error(errorMessage, {
         toastId: API_ERROR_TOAST_ID,
       });
     return {
@@ -58,6 +61,16 @@ export async function makeApiCall(path, body, method, jsonous = true) {
       message: error,
     };
   }
+}
+
+function getErrorMessage(error) {
+  if (Array.isArray(error)) {
+    return Object.values(error[0].constraints)[0];
+  }
+  if (error) {
+    return error;
+  }
+  return messages.GENERIC_ERROR;
 }
 
 function storeUserInLocalStorage(user = currentUser) {


### PR DESCRIPTION
fix #778 

Currently, the client doesn't know how to handle server validation errors payload. So far, the server returns only string errors.
The server validation errors' payload is different and contains an array of errors. This why the client didn't show anything and just closed the modal.

This PRs aims to handle them and show the validation error in a red toast, the same way it does with string base errors.
Although it doesn't solve directly the client validation of the 400 characters but I believe it's a better approach since we might change the limit from time to time.