### PR TITLE
improve(modal): move closeModal to context + ui and animation

### DIFF
--- a/src/Me/Modals/EditMentorDetails.tsx
+++ b/src/Me/Modals/EditMentorDetails.tsx
@@ -23,7 +23,6 @@ import { SelectProps } from '../components/Select/Select';
 type EditMentorDetailsProps = {
   userDetails: User;
   updateMentor: (userInfo: User) => void;
-  closeModal: () => void;
 };
 
 const EditDetails = styled.div`
@@ -95,7 +94,6 @@ const DeleteAccountContainer = styled.div``;
 const EditMentorDetails = ({
   userDetails: { avatar, ...details },
   updateMentor,
-  closeModal,
 }: EditMentorDetailsProps) => {
   const [mentorDetails, setMentorDetails] = useState(fromMtoVM(details));
 
@@ -331,7 +329,7 @@ const EditMentorDetails = ({
   };
 
   return (
-    <Modal title="Update Profile" onSave={onSubmit} closeModal={closeModal}>
+    <Modal title="Update Profile" onSave={onSubmit}>
       <EditDetails>
         <EditDetailsForm onSubmit={onSubmit}>
           <FormFields>

--- a/src/Me/Modals/MentorshipReqModals/AcceptModal.tsx
+++ b/src/Me/Modals/MentorshipReqModals/AcceptModal.tsx
@@ -5,49 +5,43 @@ import { ReactComponent as MentorshipSvg } from '../../../assets/me/mentorship.s
 type AcceptModalProps = {
   username: string;
   onClose(): void;
-  closeModal(): void;
 };
 
-const AcceptModal = ({ username, onClose, closeModal }: AcceptModalProps) => (
-  <Modal
-    center
-    title="Mentorship Started"
-    closeModal={() => {
-      onClose && onClose();
-      closeModal();
-    }}
-  >
-    <Body>
-      <MentorshipSvg />
-      <p>
-        Awesome! You are now Mentoring <b>{username}!</b> Please make sure to
-        follow our{' '}
-        <a
-          href="https://docs.google.com/document/d/1zKCxmIh0Sd4aWLiQncICOGm6uf38S0kJ0xb0qErNFVA/edit"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Guidelines
-        </a>{' '}
-        and our{' '}
-        <a
-          href="https://github.com/Coding-Coach/find-a-mentor/blob/master/CODE_OF_CONDUCT.md#our-standards"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Code of Conduct
-        </a>
-        .
-      </p>
-      <h3>What's next?</h3>
-      <div>
-        We just sent an email to <b>{username}</b> to inform them the happy
-        news. In this email we also included one of your contact channels. At
-        this point they also have access to your channels so they probably will
-        contact you soon.
-      </div>
-    </Body>
-  </Modal>
-);
+const AcceptModal = ({ username, onClose }: AcceptModalProps) => {
+  return (
+    <Modal center title="Mentorship Started" onClose={onClose}>
+      <Body>
+        <MentorshipSvg />
+        <p>
+          Awesome! You are now Mentoring <b>{username}!</b> Please make sure to
+          follow our{' '}
+          <a
+            href="https://docs.google.com/document/d/1zKCxmIh0Sd4aWLiQncICOGm6uf38S0kJ0xb0qErNFVA/edit"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Guidelines
+          </a>{' '}
+          and our{' '}
+          <a
+            href="https://github.com/Coding-Coach/find-a-mentor/blob/master/CODE_OF_CONDUCT.md#our-standards"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Code of Conduct
+          </a>
+          .
+        </p>
+        <h3>What's next?</h3>
+        <div>
+          We just sent an email to <b>{username}</b> to inform them the happy
+          news. In this email we also included one of your contact channels. At
+          this point they also have access to your channels so they probably
+          will contact you soon.
+        </div>
+      </Body>
+    </Modal>
+  );
+};
 
 export default AcceptModal;

--- a/src/Me/Modals/MentorshipReqModals/DeclineModal.tsx
+++ b/src/Me/Modals/MentorshipReqModals/DeclineModal.tsx
@@ -22,29 +22,20 @@ type DeclineModalProps = {
   username: string;
   onSave(message: string | null): void;
   onClose(): void;
-  closeModal(): void;
 };
 
-const DeclineModal = ({
-  username,
-  onSave,
-  onClose,
-  closeModal,
-}: DeclineModalProps) => {
+const DeclineModal = ({ username, onSave, onClose }: DeclineModalProps) => {
   const [loadingState, setLoadingState] = useState(false);
   const message = useRef<string | null>(null);
 
   return (
     <Modal
       center
-      title="Mentorship Declined"
+      title="Decline Mentorship"
+      onClose={onClose}
       onSave={() => {
         setLoadingState(true);
         onSave(message.current);
-      }}
-      closeModal={() => {
-        onClose();
-        closeModal();
       }}
     >
       <Body>

--- a/src/Me/Modals/MentorshipReqModals/MentorshipRequest.js
+++ b/src/Me/Modals/MentorshipReqModals/MentorshipRequest.js
@@ -36,7 +36,7 @@ const ErrorMessage = styled.div`
   color: var(--form-text-invalid);
 `;
 
-const MentorshipRequest = ({ mentor, closeModal }) => {
+const MentorshipRequest = ({ mentor }) => {
   const [confirmed, setConfirmed] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [mentorshipRequestDetails, setMentorshipRequestDetails] = useState(
@@ -155,10 +155,10 @@ const MentorshipRequest = ({ mentor, closeModal }) => {
     <Modal
       title="Mentorship Request"
       onSave={confirmed ? null : onSubmit}
-      closeModal={closeModal}
       submitLabel="Send Request"
       isValid={errors?.isValid}
       isLoading={isLoading}
+      center
     >
       {confirmed ? (
         <Body>

--- a/src/Me/Modals/MentorshipReqModals/stories/AcceptModal.stories.tsx
+++ b/src/Me/Modals/MentorshipReqModals/stories/AcceptModal.stories.tsx
@@ -11,6 +11,6 @@ const onClose = action('onClose');
 
 export const Default = () => (
   <StoriesContainer>
-    <AcceptModal username="John Doe" onClose={onClose} closeModal={() => {}} />
+    <AcceptModal username="John Doe" onClose={onClose} />
   </StoriesContainer>
 );

--- a/src/Me/Modals/MentorshipReqModals/stories/DeclineModal.stories.tsx
+++ b/src/Me/Modals/MentorshipReqModals/stories/DeclineModal.stories.tsx
@@ -12,11 +12,6 @@ const onSave = action('onSave');
 
 export const Default = () => (
   <StoriesContainer>
-    <DeclineModal
-      username="Brent M Clark"
-      onClose={onClose}
-      onSave={onSave}
-      closeModal={() => {}}
-    />
+    <DeclineModal username="Brent M Clark" onClose={onClose} onSave={onSave} />
   </StoriesContainer>
 );

--- a/src/Me/Modals/MentorshipReqModals/stories/MentorshipRequest.stories.tsx
+++ b/src/Me/Modals/MentorshipReqModals/stories/MentorshipRequest.stories.tsx
@@ -8,6 +8,6 @@ export default {
 
 export const Default = () => (
   <StoriesContainer>
-    <MentorshipRequest mentor="John Doe" closeModal={() => {}} />
+    <MentorshipRequest mentor="John Doe" />
   </StoriesContainer>
 );

--- a/src/Me/Modals/Modal.tsx
+++ b/src/Me/Modals/Modal.tsx
@@ -1,17 +1,18 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useContext, useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import _Button from '../components/Button';
 import { desktop, mobile } from '../styles/shared/devices';
 import { CSSTransition } from 'react-transition-group';
 import { ReactComponent as CloseSvg } from '../../assets/me/close.svg';
+import { ModalContext } from '../../context/modalContext/ModalContext';
 
 type ModalProps = {
   title: string;
   center?: boolean;
   isLoading?: boolean;
   submitLabel?: string;
-  closeModal: () => void;
-  onSave?: (e: React.SyntheticEvent) => void;
+  onSave?(e: React.SyntheticEvent): void;
+  onClose?(): void;
 };
 
 const Button = styled(_Button)`
@@ -49,7 +50,7 @@ const Title = styled.header`
   font-weight: 700;
   line-height: 34px;
   text-align: center;
-  margin: 50px 0;
+  margin: 40px 0 20px;
 `;
 
 const Footer = styled.footer`
@@ -76,8 +77,6 @@ const ButtonBar = styled.div`
 `;
 
 const Center = css`
-  left: 50%;
-  top: 50%;
   height: auto;
   width: auto;
   box-shadow: 0 0 4px 0 rgba(17, 22, 26, 0.16),
@@ -92,17 +91,31 @@ const Center = css`
 const Cover = css`
   height: 100vh;
   width: 100vw;
-  top: 0;
-  left: 0;
+`;
+
+const Overlay = styled.div<{ posCenter: boolean }>`
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${props =>
+    props.posCenter &&
+    `
+    backdrop-filter: blur(1px);
+    background: #00000030;
+  `}
 `;
 
 const ModalContainer = styled.div<{ posCenter: boolean }>`
-  z-index: 99;
-  font-family: 'Lato', sans-serif;
   display: flex;
-  position: fixed;
-  background-color: #fff;
+  position: relative;
   flex-direction: column;
+  background-color: #fff;
+  backface-visibility: hidden;
+  will-change: transform, opacity;
 
   ${Cover}
   @media ${mobile} {
@@ -119,7 +132,7 @@ const transitionStyle = (
   <style>{`
   .modal-enter {
     opacity: 0;
-    transform: scale(.9)
+    transform: scale(.9);
   }
   .modal-enter-active {
     opacity: 1;
@@ -136,14 +149,8 @@ const transitionStyle = (
 const transitionCenter = (
   <style>{`
     @media ${desktop} {
-    .modal-exit,
-    .modal-enter {
-      transform: scale(.8) translate(calc(-50%), -60%);
-    }
-    .modal-enter-active,
-    .modal-enter-done {
-      /* INFO: Taking sidenav into account (75px) */
-        transform: translate(calc(-50% + 75px/2), -50%);
+      .modal-enter-active,
+      .modal-enter-done {
         transition-timing-function: cubic-bezier(0.18, 0.89, 0.04, 1.4)
       }
     }
@@ -153,16 +160,22 @@ const transitionCenter = (
 export const Modal: FC<ModalProps> = ({
   title,
   onSave,
+  onClose,
   children,
-  closeModal,
   center = false,
   isLoading = false,
   submitLabel = 'Save',
 }) => {
+  const { closeModal } = useContext(ModalContext);
   const [visible, setVisible] = useState(false);
 
   const save = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     onSave?.(e);
+  };
+
+  const close = () => {
+    closeModal();
+    onClose?.();
   };
 
   useEffect(() => {
@@ -170,7 +183,7 @@ export const Modal: FC<ModalProps> = ({
   }, []);
 
   return (
-    <>
+    <Overlay posCenter={center}>
       {transitionStyle}
       {center && transitionCenter}
 
@@ -180,7 +193,7 @@ export const Modal: FC<ModalProps> = ({
         classNames="modal"
         mountOnEnter
         unmountOnExit
-        onExited={closeModal}
+        onExited={close}
       >
         <ModalContainer posCenter={center}>
           <CloseIconButton onClick={() => setVisible(false)}>
@@ -209,6 +222,6 @@ export const Modal: FC<ModalProps> = ({
           </Footer>
         </ModalContainer>
       </CSSTransition>
-    </>
+    </Overlay>
   );
 };

--- a/src/Me/Profile/Profile.tsx
+++ b/src/Me/Profile/Profile.tsx
@@ -22,7 +22,6 @@ const Profile: FC = () => {
     <EditMentorDetails
       userDetails={currentUser!}
       updateMentor={handleUpdateMentor}
-      closeModal={() => {}}
     />
   );
 

--- a/src/context/modalContext/ModalContext.tsx
+++ b/src/context/modalContext/ModalContext.tsx
@@ -1,33 +1,26 @@
-import React, { FC } from 'react';
+import { createContext, FC } from 'react';
 import { ModalProvider, useModal as rmhUseModal } from 'react-modal-hook';
 
-const BODY_HAS_CLASS_MODAL = 'has-modal';
+export const ModalContext = createContext<{
+  closeModal(): void;
+}>({closeModal: () => {}});
 
 export const ModalHookProvider: FC = ({ children }) => (
   <ModalProvider>{children}</ModalProvider>
 );
 
 export function useModal(modal: JSX.Element, deps?: any[]): [openModal: () => void, closeModal: () => void] {
-  const onOpenModal = (openModal: () => void) => () => {
-    document.body.classList.add(BODY_HAS_CLASS_MODAL);
-    openModal();
-  };
-
-  const onCloseModal = (closeModal: () => void) => () => {
-    document.body.classList.remove(BODY_HAS_CLASS_MODAL);
-    closeModal();
-  };
-
   const [openModal, closeModal] = rmhUseModal(() => {
     const { type: ModalComponent, props, key } = modal;
     return (
-      <ModalComponent
-        key={key}
-        {...props}
-        closeModal={onCloseModal(closeModal)}
-      />
+      <ModalContext.Provider value={{closeModal}}>
+        <ModalComponent
+          key={key}
+          {...props}
+        />
+      </ModalContext.Provider>
     );
   }, deps);
 
-  return [onOpenModal(openModal), onCloseModal(closeModal)];
+  return [openModal, closeModal];
 }


### PR DESCRIPTION
- Move `closeModal` to modal context to avoid the (types) need to pass from the caller.
- Improve UI - Add an overlay (half opacity + blur) to let the user focus on the modal.
