### PR TITLE
Build Storybook during deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:unit": "react-scripts test",
     "test:unit:update-snapshot": "react-scripts test -u",
     "eject": "react-scripts eject",
-    "predeploy": "yarn run build",
+    "predeploy": "yarn build && yarn build-storybook",
     "deploy": "gh-pages -d build",
     "prettier": "prettier \"**/*.{json,js}\" --check --loglevel log",
     "prettier:fix:file": "prettier --write",


### PR DESCRIPTION
https://mentors.codingcoach.io/sb/ is supposed to show the Storybook according to the README. This change causes Storybook to be built during the deploy. I verified that this works by going to the gh-pages version of my forked project: https://kevinweber.github.io/find-a-mentor/sb/