### PR TITLE
Prevent User Not Found toast on user profile page load

### DIFF
--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -53,7 +53,9 @@ export const UserProfile = () => {
       }
       setIsLoading(false);
     }
-    fetchMentor();
+    if (id) {
+      fetchMentor();
+    }
   }, [id, api]);
 
   if (isLoading) {


### PR DESCRIPTION
Fixes: https://github.com/orgs/Coding-Coach/projects/3#card-78129813

### Notes

Since the app takes a brief moment to load, it was sending `undefined` as the `userid` to `getUser`.  Everything would eventually snap into place and work fine, but the toast for the bad request would still show, which was the correct thing to do.  Now, we don't fire that API call until we have an id.