### PR TITLE
Remove react-helmet in favor of next/head

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "react-aria-offcanvas": "^1.3.4",
     "react-autocomplete": "^1.8.1",
     "react-dom": "^16.9.0",
-    "react-helmet": "^6.1.0",
     "react-infinite-scroll-component": "^4.5.3",
     "react-infinite-scroller": "^1.2.4",
     "react-modal-hook": "^3.0.0",

--- a/src/Me/Me.tsx
+++ b/src/Me/Me.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import styled from 'styled-components/macro';
-import { Helmet } from 'react-helmet';
+import Head from 'next/head'
 import { useRouter } from 'next/router';
 
 import Header from './Header/Header';
@@ -37,10 +37,10 @@ const Me = (props: any) => {
   return (
     <Container>
       <>
-        <Helmet>
+        <Head>
           <title>{title} | CodingCoach</title>
           <meta name="description" content="codingcoach.io application" />
-        </Helmet>
+        </Head>
         <Navbar />
         <Header title={title} />
         <Main>{children}</Main>

--- a/src/PageNotFound.tsx
+++ b/src/PageNotFound.tsx
@@ -2,7 +2,7 @@ import notFoundImage from './assets/404.svg';
 import Header from './components/Header/Header';
 import styled from 'styled-components';
 import Link from 'next/link';
-import { Helmet } from 'react-helmet';
+import Head from 'next/head'
 import { desktop, mobile } from './Me/styles/shared/devices';
 
 const StyleImage = styled.div`
@@ -46,9 +46,9 @@ const Content = styled.div`
 const PageNotFound = () => {
   return (
     <>
-      <Helmet>
+      <Head>
         <title>Page not found | CodingCoach</title>
-      </Helmet>
+      </Head>
       <Header />
       <Content>
         <div className="container py-16 blog-content md:flex md:py-64">

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -51,7 +51,7 @@ function Navigation({ isAuthenticated, onOpenModal }) {
           target="_blank"
           rel="noopener noreferrer"
         >
-          Sessions Calender
+          Sessions Calendar
         </Link>
       </List>
     </Nav>

--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet';
+import Head from 'next/head'
 import styled from 'styled-components/macro';
 import { useRouter } from 'next/router';
 
@@ -68,9 +68,9 @@ export const UserProfile = () => {
 
   return (
     <UserProfileContainer>
-      <Helmet>
+      <Head>
         <title>{`${prefix} | ${user?.name}`}</title>
-      </Helmet>
+      </Head>
       <Link href={urls.root.get()}>Back to mentors list</Link>
       <Card
         appearance="extended"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11898,7 +11898,7 @@ react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
 
-react-fast-compare@^3.0.1, react-fast-compare@^3.1.1, react-fast-compare@^3.2.0:
+react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
 
@@ -11911,15 +11911,6 @@ react-helmet-async@^1.0.7:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
-
-react-helmet@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.7.2"
-    react-fast-compare "^3.1.1"
-    react-side-effect "^2.1.0"
 
 react-infinite-scroll-component@^4.5.3:
   version "4.5.3"
@@ -12065,10 +12056,6 @@ react-select@^3.0.4:
     prop-types "^15.6.0"
     react-input-autosize "^3.0.0"
     react-transition-group "^4.3.0"
-
-react-side-effect@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
 
 react-sizeme@^3.0.1:
   version "3.0.2"


### PR DESCRIPTION
Closes: https://github.com/orgs/Coding-Coach/projects/3#card-78303000

### Description

React Helmet is great, but the native `next/head` is better for Nextjs applications.  So, we switch.