### PR TITLE
fix: mentor's channel are not available

### DIFF
--- a/src/Me/MentorshipRequests/UsersList.tsx
+++ b/src/Me/MentorshipRequests/UsersList.tsx
@@ -95,6 +95,7 @@ const renderList = ({
         <li key={id}>
           <RichItem
             id={id}
+            userId={user.id}
             avatar={getAvatarUrl(user.avatar)}
             title={user.name}
             subtitle={user.title}

--- a/src/Me/components/RichList/ReachItemTypes.d.ts
+++ b/src/Me/components/RichList/ReachItemTypes.d.ts
@@ -8,6 +8,7 @@ export type RichItemTagTheme =
 
 export type RichItemProps = {
   id: string;
+  userId: string;
   avatar: string;
   title: string;
   subtitle: string;

--- a/src/Me/components/RichList/RichItem.tsx
+++ b/src/Me/components/RichList/RichItem.tsx
@@ -1,9 +1,12 @@
 import { FC } from 'react';
 import styled from 'styled-components';
+import Link from '../../../components/Link/Link';
+import { useRoutes } from '../../../hooks/useRoutes';
 import { RichItemProps, RichItemTagTheme } from './ReachItemTypes';
 
 const RichItem: FC<RichItemProps> = ({
   id,
+  userId,
   avatar,
   title,
   subtitle,
@@ -13,11 +16,12 @@ const RichItem: FC<RichItemProps> = ({
   onClick,
   children,
 }) => {
+  const routes = useRoutes();
   return (
     <Root highlight={!!children && !expand} expanded={expand}>
       <Main onClick={() => onClick(id)}>
         <ItemRow>
-          <ItemAvatar>{avatar && <img src={avatar} alt="avatar" />}</ItemAvatar>
+          <ItemAvatar href={routes.user.get(userId)}>{avatar && <img src={avatar} alt="avatar" />}</ItemAvatar>
           <Titles>
             <ItemRow>
               <Title>{title}</Title>
@@ -71,7 +75,7 @@ const Titles = styled(ItemCol)`
   }
 `;
 
-const ItemAvatar = styled.div`
+const ItemAvatar = styled(Link)`
   user-select: none;
   width: 45px;
   overflow: hidden;

--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Head from 'next/head';
 import styled from 'styled-components/macro';
 
@@ -11,6 +11,7 @@ import { useFilters } from '../../context/filtersContext/FiltersContext';
 import { useMentors } from '../../context/mentorsContext/MentorsContext';
 import { useRoutes } from '../../hooks/useRoutes';
 import { getTitleTags } from '../../helpers/getTitleTags';
+import { useApi } from '../../context/apiContext/ApiContext';
 
 const UserProfileContainer = styled.div`
   display: flex;
@@ -28,11 +29,24 @@ export const UserProfile = ({ user }: { user: User }) => {
   const title = `${prefix} | ${user?.name}`;
   const [, dispatch] = useFilters();
   const urls = useRoutes();
+  const api = useApi();
   const { favorites, addFavorite } = useMentors();
+  const [channels, setChannels] = useState<User["channels"]>([]);
 
   useEffect(() => {
     dispatch({ type: 'showFilters', payload: false });
   }, [dispatch]);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+    // once #921 done, there is no need for that
+    api.getUser(user?._id)
+      .then(({channels}) => {
+        setChannels(channels);
+      });
+  }, [api, user]);
 
   if (!user) {
     return (
@@ -48,7 +62,10 @@ export const UserProfile = ({ user }: { user: User }) => {
       <Link href={urls.root.get()}>Back to mentors list</Link>
       <Card
         appearance="extended"
-        mentor={user}
+        mentor={{
+          ...user,
+          channels,
+        }}
         onFavMentor={addFavorite}
         isFav={favorites.indexOf(user._id) > -1}
       />

--- a/src/context/apiContext/ApiContext.tsx
+++ b/src/context/apiContext/ApiContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, FC, useMemo } from 'react';
 import { AuthContext } from '../authContext/AuthContext';
 import ApiService from '../../api';
 
-export const ApiContext = createContext<any>({});
+export const ApiContext = createContext<ApiService>(null);
 
 export const ApiProvider: FC = (props: any) => {
     const { children } = props
@@ -11,7 +11,7 @@ export const ApiProvider: FC = (props: any) => {
     return <ApiContext.Provider value={api}>{children}</ApiContext.Provider>
 };
 
-export function useApi(): any {
+export function useApi(): ApiService {
   const api = useContext(ApiContext);
   return api;
 }

--- a/src/hooks/useRoutes.ts
+++ b/src/hooks/useRoutes.ts
@@ -4,7 +4,8 @@ import { User } from '../types/models';
 export const useRoutes = () => {
   const { asPath } = useRouter();
   const getUrlWithFilterParams = (url: string) => {
-    const queryParamsOnly = /(.*)(?<query>\?.*)/.exec(asPath)?.groups.query ?? '';
+    const queryParamsOnly =
+      /(.*)(?<query>\?.*)/.exec(asPath)?.groups.query ?? '';
     return url + queryParamsOnly;
   };
 
@@ -13,7 +14,12 @@ export const useRoutes = () => {
       get: () => getUrlWithFilterParams('/'),
     },
     user: {
-      get: (user: User) => getUrlWithFilterParams(`/u/${user._id}`),
+      get: (userOrUsreId: User | string) =>
+        getUrlWithFilterParams(
+          `/u/${
+            typeof userOrUsreId === 'string' ? userOrUsreId : userOrUsreId._id
+          }`
+        ),
     },
     me: {
       get: () => '/me',


### PR DESCRIPTION
It's a very major bug!

Mentees can't get their mentor details since we fetch the mentor details in the server (for ssr) but the call is anonymous so the channels are always an empty array.

The patch for now is to take the channels from the mentor list we fetch anyway (and it's not anonymous).
The perfect ultimate solution is to make the ssr call not anonymous (by moving the auth details from the localStorage to cookie - see #921) so the API wiil return the channels with the user response.