### PR TITLE
fix: mentors channels are not available when they are not available

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -220,7 +220,8 @@ const Card = ({ mentor, onFavMentor, isFav, appearance }: CardProps) => {
   };
 
   const getChannelsContent = () => {
-    if (!availability) {
+    const isMyMentor = mentor.channels.length > 0;
+    if (!availability && !isMyMentor) {
       return <MentorNotAvailable />;
     }
     return appearance === 'extended' ? (


### PR DESCRIPTION
When I go to my mentor page and (s)he is not available I can't get their contact details.
Why? Because we first check if the mentor is available. If not we show the not available line.
The solution is to check also if (s)he is my mentor.