### PR TITLE
Bug Fix - fixed date on profile card showing months instead of year.

### DIFF
--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -20,5 +20,5 @@ export function formatTimeAgo(timestamp: number | Date | string) {
   if (time < 30) return `${Math.floor(time)} Days Ago`;
   if (time < 365) return `${Math.floor(time / 30)} Months Ago`;
 
-  return `${Math.floor(time / 365)} Months Ago`;
+  return `${Math.floor(time / 365)} Year Ago`;
 }


### PR DESCRIPTION
For users that joined over a year ago. The profile card in find-a-mentor returns months instead of years. For example, I joined exactly one year ago but the profile card shows 1months ago.