### PR TITLE
fix(mentorship-request): validation keeps show up when it's resolved on server error

### DIFF
--- a/src/Me/Modals/MentorshipRequestModals/MentorshipRequest.js
+++ b/src/Me/Modals/MentorshipRequestModals/MentorshipRequest.js
@@ -130,7 +130,6 @@ const MentorshipRequest = ({ mentor }) => {
         ] = `"${config.label}" should be longer than 30 characters`;
       }
     });
-
     setErrors(_errors);
     return Object.keys(_errors).length === 0;
   };
@@ -146,10 +145,10 @@ const MentorshipRequest = ({ mentor }) => {
     if (response.success) {
       setConfirmed(true);
     } else {
-      setErrors({
-        ...errors,
+      setErrors(currentErrors => ({
+        ...currentErrors,
         form: response.message,
-      });
+      }));
     }
     setIsLoading(false);
   };


### PR DESCRIPTION
The bug is that once a field’s validation failed it didn’t became valid even when the content has extended **and** the server returns an error